### PR TITLE
Fix raw GT columns leaking to final outputs

### DIFF
--- a/tests/unit/stages/test_output_stages.py
+++ b/tests/unit/stages/test_output_stages.py
@@ -539,6 +539,48 @@ class TestTSVOutputStage:
         assert stage.dependencies == {"dataframe_loading", "variant_identifier"}
         assert stage.soft_dependencies == {"variant_scoring", "final_filtering", "pseudonymization"}
 
+    def test_tsv_output_drops_raw_gt_columns_when_packed_gt_exists(self, context):
+        """Final TSV should not leak raw GEN[N].GT columns by default."""
+        context.vcf_samples = ["Sample1", "Sample2"]
+        context.current_dataframe = pd.DataFrame(
+            {
+                "CHROM": ["chr1"],
+                "POS": [100],
+                "GT": ["Sample1(0/1)"],
+                "GEN[0].GT": ["0/1"],
+                "GEN[1].GT": ["0/0"],
+            }
+        )
+
+        stage = TSVOutputStage()
+        result = stage(context)
+
+        output_df = pd.read_csv(result.final_output_path, sep="\t")
+        assert list(output_df.columns) == ["CHROM", "POS", "GT"]
+        assert "GEN[0].GT" not in result.current_dataframe.columns
+        assert "GEN[1].GT" not in result.current_dataframe.columns
+
+    def test_tsv_output_keeps_raw_gt_columns_with_no_replacement(self, context):
+        """--no-replacement explicitly preserves raw per-sample GT output."""
+        context.config["no_replacement"] = True
+        context.vcf_samples = ["Sample1", "Sample2"]
+        context.current_dataframe = pd.DataFrame(
+            {
+                "CHROM": ["chr1"],
+                "POS": [100],
+                "GT": ["Sample1(0/1)"],
+                "GEN[0].GT": ["0/1"],
+                "GEN[1].GT": ["0/0"],
+            }
+        )
+
+        stage = TSVOutputStage()
+        result = stage(context)
+
+        output_df = pd.read_csv(result.final_output_path, sep="\t")
+        assert "GEN[0].GT" in output_df.columns
+        assert "GEN[1].GT" in output_df.columns
+
 
 class TestExcelReportStage:
     """Test ExcelReportStage."""
@@ -662,6 +704,40 @@ class TestExcelReportStage:
         )
         assert "nephro_candidate_score" in passed_df.columns
         assert "ngs" in passed_df.columns
+
+    @patch("variantcentrifuge.stages.output_stages.finalize_excel_file")
+    @patch("variantcentrifuge.stages.output_stages.convert_to_excel")
+    def test_excel_output_drops_raw_gt_columns_when_packed_gt_exists(
+        self, mock_convert, mock_finalize, context
+    ):
+        """Final Excel DataFrame should not include raw GEN[N].GT columns by default."""
+        context.vcf_samples = ["Sample1", "Sample2"]
+        context.current_dataframe = pd.DataFrame(
+            {
+                "CHROM": ["chr1"],
+                "POS": [100],
+                "GT": ["Sample1(0/1)"],
+                "GEN[0].GT": ["0/1"],
+                "GEN[1].GT": ["0/0"],
+            }
+        )
+        context.mark_complete("tsv_output")
+        context.mark_complete("metadata_generation")
+        context.mark_complete("statistics_generation")
+        context.final_output_path = context.workspace.output_dir / "output.tsv"
+        context.final_output_path.touch()
+
+        expected_excel_path = str(context.workspace.output_dir / "output.xlsx")
+        mock_convert.return_value = expected_excel_path
+        Path(expected_excel_path).touch()
+
+        stage = ExcelReportStage()
+        stage(context)
+
+        passed_df = mock_convert.call_args.kwargs.get("df")
+        assert passed_df is not None
+        assert list(passed_df.columns) == ["CHROM", "POS", "GT"]
+        mock_finalize.assert_called_once()
 
 
 class TestHTMLReportStage:

--- a/tests/unit/test_gt_lifecycle.py
+++ b/tests/unit/test_gt_lifecycle.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from variantcentrifuge.stages.output_stages import (
+    _collapse_per_sample_gt_columns_for_output,
     _find_per_sample_gt_columns,
     reconstruct_gt_column,
 )
@@ -111,3 +112,56 @@ class TestGtColumnsConsolidation:
 
         df = pd.DataFrame({"GENE": ["A"], "CHROM": ["1"]})
         assert _find_gt_columns(df) == []
+
+
+@pytest.mark.unit
+class TestCollapsePerSampleGtColumnsForOutput:
+    """Regression tests for final output GT column cleanup."""
+
+    def test_existing_packed_gt_drops_raw_columns_by_default(self):
+        df = pd.DataFrame(
+            {
+                "CHROM": ["1"],
+                "POS": [100],
+                "GT": ["Sample1(0/1)"],
+                "GEN[0].GT": ["0/1"],
+                "GEN[1].GT": ["0/0"],
+            }
+        )
+
+        result = _collapse_per_sample_gt_columns_for_output(df, ["Sample1", "Sample2"])
+
+        assert list(result.columns) == ["CHROM", "POS", "GT"]
+
+    def test_no_replacement_keeps_raw_columns(self):
+        df = pd.DataFrame(
+            {
+                "CHROM": ["1"],
+                "POS": [100],
+                "GT": ["Sample1(0/1)"],
+                "GEN[0].GT": ["0/1"],
+                "GEN[1].GT": ["0/0"],
+            }
+        )
+
+        result = _collapse_per_sample_gt_columns_for_output(
+            df, ["Sample1", "Sample2"], no_replacement=True
+        )
+
+        assert "GEN[0].GT" in result.columns
+        assert "GEN[1].GT" in result.columns
+
+    def test_missing_packed_gt_reconstructs_and_drops_raw_columns(self):
+        df = pd.DataFrame(
+            {
+                "CHROM": ["1"],
+                "POS": [100],
+                "GEN_0__GT": ["0/1"],
+                "GEN_1__GT": ["0/0"],
+            }
+        )
+
+        result = _collapse_per_sample_gt_columns_for_output(df, ["Sample1", "Sample2"])
+
+        assert list(result.columns) == ["CHROM", "POS", "GT"]
+        assert result.loc[0, "GT"] == "Sample1(0/1)"

--- a/variantcentrifuge/stages/output_stages.py
+++ b/variantcentrifuge/stages/output_stages.py
@@ -129,6 +129,38 @@ def reconstruct_gt_column(df: pd.DataFrame, vcf_samples: list[str]) -> pd.DataFr
     return df
 
 
+def _collapse_per_sample_gt_columns_for_output(
+    df: pd.DataFrame,
+    vcf_samples: list[str] | None,
+    *,
+    no_replacement: bool = False,
+) -> pd.DataFrame:
+    """Remove raw per-sample GT columns from final outputs unless explicitly requested.
+
+    Analysis stages may keep GEN[N].GT columns for burden/association logic. Final
+    TSV/Excel output should expose only the packed GT representation by default.
+    """
+    if no_replacement:
+        return df
+
+    gt_cols = _find_per_sample_gt_columns(df)
+    if not gt_cols:
+        return df
+
+    if "GT" not in df.columns:
+        if vcf_samples:
+            return reconstruct_gt_column(df, vcf_samples)
+        logger.warning(
+            "Per-sample GT columns found in final output but VCF sample names are "
+            "unavailable; leaving columns unchanged"
+        )
+        return df
+
+    df = df.drop(columns=gt_cols)
+    logger.info(f"Dropped {len(gt_cols)} per-sample GT columns from final output")
+    return df
+
+
 class VariantIdentifierStage(Stage):
     """Generate unique variant identifiers."""
 
@@ -570,12 +602,14 @@ class TSVOutputStage(Stage):
             logger.error("No data to write")
             return context
 
-        # Phase 11: Reconstruct GT column from per-sample columns if needed
-        if context.vcf_samples and "GT" not in df.columns:
-            gt_cols = _find_per_sample_gt_columns(df)
-            if gt_cols:
-                df = reconstruct_gt_column(df, context.vcf_samples)
-                context.current_dataframe = df
+        # Phase 11: Keep per-sample GT columns available for analysis, but collapse
+        # them out of final materialized outputs unless users requested raw output.
+        df = _collapse_per_sample_gt_columns_for_output(
+            df,
+            context.vcf_samples,
+            no_replacement=context.config.get("no_replacement", False),
+        )
+        context.current_dataframe = df
 
         # Determine output path
         output_file = context.config.get("output_file")
@@ -708,16 +742,16 @@ class ExcelReportStage(Stage):
         )
         if source_df is not None:
             excel_df = source_df.copy()
+            excel_df = _collapse_per_sample_gt_columns_for_output(
+                excel_df,
+                context.vcf_samples,
+                no_replacement=context.config.get("no_replacement", False),
+            )
             # Drop internal cache columns before Excel output
             cache_cols = [c for c in excel_df.columns if c.startswith("_")]
             if cache_cols:
                 excel_df = excel_df.drop(columns=cache_cols)
                 logger.debug(f"Dropped {len(cache_cols)} cache columns: {cache_cols}")
-            # Phase 11: Reconstruct GT column from per-sample columns if needed
-            if context.vcf_samples and "GT" not in excel_df.columns:
-                gt_cols = _find_per_sample_gt_columns(excel_df)
-                if gt_cols:
-                    excel_df = reconstruct_gt_column(excel_df, context.vcf_samples)
             # Restore original column names for Excel output
             if context.column_rename_map:
                 reverse_map = {v: k for k, v in context.column_rename_map.items()}


### PR DESCRIPTION
## Summary

Fixes #92.

Final TSV/Excel output now collapses raw per-sample `GEN[N].GT` columns out of materialized outputs by default, even when a packed `GT` column already exists from analysis. This preserves the documented default genotype replacement behavior while still allowing raw per-sample output when `--no-replacement` is explicitly set.

## Root cause

`VariantAnalysisStage` reconstructs a packed `GT` column for `analyze_variants`, then re-attaches raw per-sample GT columns so downstream burden/association stages can use them. The output stages only called `reconstruct_gt_column()` when `GT` was missing, so a DataFrame containing both `GT` and `GEN[N].GT` skipped cleanup and leaked raw genotype columns to TSV/XLSX.

## Changes

- Added `_collapse_per_sample_gt_columns_for_output()` in `output_stages.py`.
- Applied the helper in both `TSVOutputStage` and `ExcelReportStage`.
- Preserved `--no-replacement` behavior: raw `GEN[N].GT` columns remain in final outputs only when requested.
- Added helper-level and stage-level regression tests for default collapse and explicit raw-output behavior.

## Validation

- `python -m pytest tests/unit/test_gt_lifecycle.py tests/unit/stages/test_output_stages.py::TestTSVOutputStage tests/unit/stages/test_output_stages.py::TestExcelReportStage -q`
- `python -m ruff format variantcentrifuge/stages/output_stages.py tests/unit/test_gt_lifecycle.py tests/unit/stages/test_output_stages.py --check`
- `python -m ruff check variantcentrifuge/stages/output_stages.py tests/unit/test_gt_lifecycle.py tests/unit/stages/test_output_stages.py`
- `python -m mypy variantcentrifuge/stages/output_stages.py`
- `python -m pytest tests/unit/test_gt_lifecycle.py tests/unit/test_gt_reconstruction.py tests/unit/stages/test_output_stages.py tests/unit/test_pipeline_io_elimination.py tests/unit/stages/test_analysis_stages.py::TestVariantAnalysisStage -q`
- `make ci-check` (`2089 passed, 3 skipped, 132 deselected`)
