### PR TITLE
Fix custom annotation config normalization

### DIFF
--- a/tests/integration/test_create_stages_from_config.py
+++ b/tests/integration/test_create_stages_from_config.py
@@ -5,9 +5,11 @@ This tests the TD-02 fix: previously perform_association and perform_gene_burden
 were not mapped, so passing them in config silently had no effect.
 """
 
+import argparse
+
 import pytest
 
-from variantcentrifuge.pipeline import create_stages_from_config
+from variantcentrifuge.pipeline import build_pipeline_stages, create_stages_from_config
 from variantcentrifuge.stages.analysis_stages import (
     AssociationAnalysisStage,
     CustomAnnotationStage,
@@ -114,5 +116,37 @@ def test_gene_list_files_alias_activates_custom_annotation_stages():
     """Gene-list files alias must activate custom annotation stages."""
     stage_types = _stage_types({"annotate_gene_list_files": ["genes.txt"]})
 
+    assert AnnotationConfigLoadingStage in stage_types
+    assert CustomAnnotationStage in stage_types
+
+
+@pytest.mark.integration
+def test_build_pipeline_stages_does_not_mutate_caller_config_dict():
+    """Stage selection may normalize a copy, but must not rewrite args.config."""
+    config = {"annotate_bed": "regions.bed"}
+    original_config = config.copy()
+    args = argparse.Namespace(
+        config=config,
+        annotate_bed=None,
+        annotate_gene_list=None,
+        annotate_json_genes=None,
+        threads=1,
+        late_filtering=False,
+        no_replacement=True,
+        append_extra_sample_fields=None,
+        no_stats=True,
+        perform_gene_burden=False,
+        perform_association=False,
+        xlsx=False,
+        excel=False,
+        html_report=False,
+        igv=False,
+        archive_results=False,
+        pca=None,
+    )
+
+    stage_types = [type(stage) for stage in build_pipeline_stages(args)]
+
+    assert config == original_config
     assert AnnotationConfigLoadingStage in stage_types
     assert CustomAnnotationStage in stage_types

--- a/tests/integration/test_create_stages_from_config.py
+++ b/tests/integration/test_create_stages_from_config.py
@@ -10,6 +10,7 @@ import pytest
 from variantcentrifuge.pipeline import create_stages_from_config
 from variantcentrifuge.stages.analysis_stages import (
     AssociationAnalysisStage,
+    CustomAnnotationStage,
     GeneBurdenAnalysisStage,
 )
 from variantcentrifuge.stages.output_stages import (
@@ -17,6 +18,7 @@ from variantcentrifuge.stages.output_stages import (
     HTMLReportStage,
     IGVReportStage,
 )
+from variantcentrifuge.stages.setup_stages import AnnotationConfigLoadingStage
 
 
 def _stage_types(config: dict) -> list[type]:
@@ -87,3 +89,30 @@ def test_igv_true_activates_igv_stage():
     """Config with igv=True must include IGVReportStage."""
     stage_types = _stage_types({"igv": True})
     assert IGVReportStage in stage_types
+
+
+@pytest.mark.integration
+def test_canonical_annotate_bed_files_activates_custom_annotation_stages():
+    """Canonical BED config key must activate custom annotation stages."""
+    stage_types = _stage_types({"annotate_bed_files": ["regions.bed"]})
+
+    assert AnnotationConfigLoadingStage in stage_types
+    assert CustomAnnotationStage in stage_types
+
+
+@pytest.mark.integration
+def test_canonical_annotate_gene_lists_activates_custom_annotation_stages():
+    """Canonical gene-list config key must activate custom annotation stages."""
+    stage_types = _stage_types({"annotate_gene_lists": ["genes.txt"]})
+
+    assert AnnotationConfigLoadingStage in stage_types
+    assert CustomAnnotationStage in stage_types
+
+
+@pytest.mark.integration
+def test_gene_list_files_alias_activates_custom_annotation_stages():
+    """Gene-list files alias must activate custom annotation stages."""
+    stage_types = _stage_types({"annotate_gene_list_files": ["genes.txt"]})
+
+    assert AnnotationConfigLoadingStage in stage_types
+    assert CustomAnnotationStage in stage_types

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -14,6 +14,35 @@ from variantcentrifuge.checkpoint import (
 )
 
 
+def _legacy_checkpoint_hash(config: dict) -> str:
+    """Return the pre-normalization checkpoint hash for a config."""
+    relevant_keys = [
+        "gene_name",
+        "gene_file",
+        "vcf_file",
+        "output_file",
+        "preset",
+        "filters",
+        "fields",
+        "threads",
+        "no_replacement",
+        "late_filtering",
+        "chunk_size",
+        "samples_file",
+        "bcftools_prefilter",
+        "final_filter",
+        "scoring_config_path",
+        "ped",
+        "inheritance_mode",
+        "annotate_bed",
+        "annotate_gene_list",
+        "annotate_json_genes",
+    ]
+    relevant_config = {k: v for k, v in config.items() if k in relevant_keys and v is not None}
+    legacy_config_str = json.dumps(relevant_config, sort_keys=True)
+    return hashlib.sha256(legacy_config_str.encode()).hexdigest()
+
+
 class TestFileInfo:
     """Test FileInfo class."""
 
@@ -194,8 +223,7 @@ class TestPipelineState:
     def test_pipeline_state_resume_preserves_legacy_no_annotation_hash(self, tmp_path):
         """Test no-annotation checkpoints remain resumable after annotation normalization."""
         config = {"gene_name": "BRCA1", "vcf_file": "input.vcf", "filters": "QUAL > 30"}
-        legacy_config_str = json.dumps(config, sort_keys=True)
-        legacy_hash = hashlib.sha256(legacy_config_str.encode()).hexdigest()
+        legacy_hash = _legacy_checkpoint_hash(config)
 
         state = PipelineState(str(tmp_path))
         state.state["pipeline_version"] = "1.0.0"
@@ -207,6 +235,90 @@ class TestPipelineState:
         new_state.load()
 
         assert new_state.can_resume(config, "1.0.0") is True
+
+    def test_pipeline_state_resume_preserves_legacy_empty_annotation_hash(self, tmp_path):
+        """Explicit empty legacy annotation checkpoints remain resumable."""
+        config = {
+            "gene_name": "BRCA1",
+            "vcf_file": "input.vcf",
+            "annotate_bed": [],
+            "annotate_gene_list": [],
+        }
+        legacy_hash = _legacy_checkpoint_hash(config)
+
+        state = PipelineState(str(tmp_path))
+        state.state["pipeline_version"] = "1.0.0"
+        state.state["start_time"] = time.time()
+        state.state["configuration_hash"] = legacy_hash
+        state.save()
+
+        new_state = PipelineState(str(tmp_path))
+        new_state.load()
+
+        assert new_state.can_resume(config, "1.0.0") is True
+
+    def test_pipeline_state_resume_preserves_legacy_bed_annotation_hash(self, tmp_path):
+        """Legacy BED annotation checkpoints resume after migrating to canonical keys."""
+        legacy_config = {"gene_name": "BRCA1", "annotate_bed": ["regions_a.bed"]}
+        legacy_hash = _legacy_checkpoint_hash(legacy_config)
+
+        state = PipelineState(str(tmp_path))
+        state.state["pipeline_version"] = "1.0.0"
+        state.state["start_time"] = time.time()
+        state.state["configuration_hash"] = legacy_hash
+        state.save()
+
+        new_state = PipelineState(str(tmp_path))
+        new_state.load()
+
+        migrated_config = {"gene_name": "BRCA1", "annotate_bed_files": ["regions_a.bed"]}
+        changed_config = {"gene_name": "BRCA1", "annotate_bed_files": ["regions_b.bed"]}
+        assert new_state.can_resume(migrated_config, "1.0.0") is True
+        assert new_state.can_resume(changed_config, "1.0.0") is False
+
+    def test_pipeline_state_resume_preserves_legacy_gene_list_annotation_hash(self, tmp_path):
+        """Legacy gene-list checkpoints resume after migrating to canonical keys."""
+        legacy_config = {"gene_name": "BRCA1", "annotate_gene_list": ["genes_a.txt"]}
+        legacy_hash = _legacy_checkpoint_hash(legacy_config)
+
+        state = PipelineState(str(tmp_path))
+        state.state["pipeline_version"] = "1.0.0"
+        state.state["start_time"] = time.time()
+        state.state["configuration_hash"] = legacy_hash
+        state.save()
+
+        new_state = PipelineState(str(tmp_path))
+        new_state.load()
+
+        migrated_config = {
+            "gene_name": "BRCA1",
+            "annotate_gene_list_files": ["genes_a.txt"],
+        }
+        changed_config = {
+            "gene_name": "BRCA1",
+            "annotate_gene_list_files": ["genes_b.txt"],
+        }
+        assert new_state.can_resume(migrated_config, "1.0.0") is True
+        assert new_state.can_resume(changed_config, "1.0.0") is False
+
+    def test_pipeline_state_resume_rejects_legacy_no_annotation_hash_when_annotation_added(
+        self, tmp_path
+    ):
+        """Legacy no-annotation checkpoints must not resume with new annotations."""
+        legacy_config = {"gene_name": "BRCA1"}
+        legacy_hash = _legacy_checkpoint_hash(legacy_config)
+
+        state = PipelineState(str(tmp_path))
+        state.state["pipeline_version"] = "1.0.0"
+        state.state["start_time"] = time.time()
+        state.state["configuration_hash"] = legacy_hash
+        state.save()
+
+        new_state = PipelineState(str(tmp_path))
+        new_state.load()
+
+        current_config = {"gene_name": "BRCA1", "annotate_bed_files": ["regions_a.bed"]}
+        assert new_state.can_resume(current_config, "1.0.0") is False
 
     def test_pipeline_state_step_tracking(self, tmp_path):
         """Test step tracking functionality."""

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,5 +1,7 @@
 """Tests for the checkpoint and resume system."""
 
+import hashlib
+import json
 import os
 import time
 
@@ -188,6 +190,23 @@ class TestPipelineState:
 
         changed_config = {"gene_name": "BRCA1", "annotate_gene_lists": ["genes_b.txt"]}
         assert new_state.can_resume(changed_config, "1.0.0") is False
+
+    def test_pipeline_state_resume_preserves_legacy_no_annotation_hash(self, tmp_path):
+        """Test no-annotation checkpoints remain resumable after annotation normalization."""
+        config = {"gene_name": "BRCA1", "vcf_file": "input.vcf", "filters": "QUAL > 30"}
+        legacy_config_str = json.dumps(config, sort_keys=True)
+        legacy_hash = hashlib.sha256(legacy_config_str.encode()).hexdigest()
+
+        state = PipelineState(str(tmp_path))
+        state.state["pipeline_version"] = "1.0.0"
+        state.state["start_time"] = time.time()
+        state.state["configuration_hash"] = legacy_hash
+        state.save()
+
+        new_state = PipelineState(str(tmp_path))
+        new_state.load()
+
+        assert new_state.can_resume(config, "1.0.0") is True
 
     def test_pipeline_state_step_tracking(self, tmp_path):
         """Test step tracking functionality."""

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -163,6 +163,32 @@ class TestPipelineState:
         # Different version - should not be compatible
         assert new_state.can_resume(config, "2.0.0") is False
 
+    def test_pipeline_state_resume_detects_canonical_bed_annotation_change(self, tmp_path):
+        """Test canonical BED annotation config affects resume compatibility."""
+        state = PipelineState(str(tmp_path))
+        config = {"gene_name": "BRCA1", "annotate_bed_files": ["regions_a.bed"]}
+        state.initialize(config, "1.0.0")
+        state.save()
+
+        new_state = PipelineState(str(tmp_path))
+        new_state.load()
+
+        changed_config = {"gene_name": "BRCA1", "annotate_bed_files": ["regions_b.bed"]}
+        assert new_state.can_resume(changed_config, "1.0.0") is False
+
+    def test_pipeline_state_resume_detects_canonical_gene_list_annotation_change(self, tmp_path):
+        """Test canonical gene list annotation config affects resume compatibility."""
+        state = PipelineState(str(tmp_path))
+        config = {"gene_name": "BRCA1", "annotate_gene_lists": ["genes_a.txt"]}
+        state.initialize(config, "1.0.0")
+        state.save()
+
+        new_state = PipelineState(str(tmp_path))
+        new_state.load()
+
+        changed_config = {"gene_name": "BRCA1", "annotate_gene_lists": ["genes_b.txt"]}
+        assert new_state.can_resume(changed_config, "1.0.0") is False
+
     def test_pipeline_state_step_tracking(self, tmp_path):
         """Test step tracking functionality."""
         state = PipelineState(str(tmp_path))

--- a/tests/test_cli_argument_parsing.py
+++ b/tests/test_cli_argument_parsing.py
@@ -11,6 +11,46 @@ of the duplicate argument parser bug and ensure all critical parameters work.
 import subprocess
 
 
+def test_cli_annotate_bed_populates_canonical_and_legacy_config_keys(monkeypatch, tmp_path):
+    from variantcentrifuge import cli as cli_module
+
+    captured_configs = []
+
+    def fake_run_pipeline(args):
+        captured_configs.append(args.config.copy())
+
+    vcf = tmp_path / "input.vcf"
+    vcf.write_text("##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n")
+    bed = tmp_path / "regions.bed"
+    bed.write_text("chr1\t99\t101\tregion\n")
+
+    monkeypatch.setattr(cli_module, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "variantcentrifuge",
+            "--vcf-file",
+            str(vcf),
+            "--gene-name",
+            "all",
+            "--filters",
+            "not_artefact",
+            "--annotate-bed",
+            str(bed),
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    exit_code = cli_module.main()
+
+    assert exit_code == 0
+    assert len(captured_configs) == 1
+    cfg = captured_configs[0]
+    assert cfg["annotate_bed_files"] == [str(bed)]
+    assert cfg["annotate_bed"] == [str(bed)]
+
+
 def test_transcript_filtering_parameters_are_documented():
     from variantcentrifuge.cli import create_parser
 

--- a/tests/test_gene_list_integration.py
+++ b/tests/test_gene_list_integration.py
@@ -130,7 +130,7 @@ def test_pipeline_with_gene_list_annotation(sample_vcf_file, gene_lists, test_da
     minimal_pipeline_test()
 
 
-def test_cli_with_gene_list_annotation(sample_vcf_file, gene_lists, test_data_dir, monkeypatch):
+def test_cli_gene_list_integration(sample_vcf_file, gene_lists, test_data_dir, monkeypatch):
     """Test that the CLI correctly handles gene list annotation."""
     from variantcentrifuge.cli import main
 
@@ -182,7 +182,11 @@ def test_cli_with_gene_list_annotation(sample_vcf_file, gene_lists, test_data_di
         cfg = run_pipeline_calls[0]
 
         assert "annotate_gene_list_files" in cfg
+        assert "annotate_gene_lists" in cfg
+        assert "annotate_gene_list" in cfg
         assert len(cfg["annotate_gene_list_files"]) == 2
+        assert cfg["annotate_gene_lists"] == cfg["annotate_gene_list_files"]
+        assert cfg["annotate_gene_list"] == cfg["annotate_gene_list_files"]
         assert gene_lists["cancer_genes"] in cfg["annotate_gene_list_files"]
         assert gene_lists["apc_genes"] in cfg["annotate_gene_list_files"]
 

--- a/tests/unit/stages/test_analysis_stages.py
+++ b/tests/unit/stages/test_analysis_stages.py
@@ -18,6 +18,7 @@ from variantcentrifuge.stages.analysis_stages import (
     VariantAnalysisStage,
     VariantScoringStage,
 )
+from variantcentrifuge.stages.setup_stages import AnnotationConfigLoadingStage
 
 
 @pytest.fixture
@@ -137,6 +138,48 @@ class TestCustomAnnotationStage:
         assert mock_load.called
         assert mock_annotate.called
         assert "Custom_Annotation" in result.current_dataframe.columns
+
+    def test_canonical_bed_config_reaches_custom_annotation(self, base_context, tmp_path):
+        """Canonical BED config should annotate variants through setup loading."""
+        bed_file = tmp_path / "GIAB_TANDEM_REPEAT.bed"
+        bed_file.write_text("chr1\t99\t101\tTR\n")
+        base_context.config["annotate_bed_files"] = [str(bed_file)]
+        base_context.config["annotate_bed"] = []
+        base_context.current_dataframe = pd.DataFrame(
+            [
+                {"CHROM": "chr1", "POS": 100, "REF": "C", "ALT": "A", "GENE": "HTT"},
+                {"CHROM": "chr1", "POS": 500, "REF": "G", "ALT": "T", "GENE": "PKD1"},
+            ]
+        )
+
+        AnnotationConfigLoadingStage()._process(base_context)
+        result = CustomAnnotationStage()._process(base_context)
+
+        annotations = result.current_dataframe["Custom_Annotation"]
+        assert "Custom_Annotation" in result.current_dataframe.columns
+        assert "Region=TR_GIAB_TANDEM_REPEAT" in annotations.iloc[0]
+        assert annotations.iloc[1] == ""
+
+    def test_canonical_gene_list_config_reaches_custom_annotation(self, base_context, tmp_path):
+        """Canonical gene-list config should annotate variants through setup loading."""
+        gene_file = tmp_path / "repeat_review_genes.txt"
+        gene_file.write_text("HTT\n")
+        base_context.config["annotate_gene_lists"] = [str(gene_file)]
+        base_context.config["annotate_gene_list"] = []
+        base_context.current_dataframe = pd.DataFrame(
+            [
+                {"CHROM": "chr1", "POS": 100, "REF": "C", "ALT": "A", "GENE": "HTT"},
+                {"CHROM": "chr1", "POS": 500, "REF": "G", "ALT": "T", "GENE": "PKD1"},
+            ]
+        )
+
+        AnnotationConfigLoadingStage()._process(base_context)
+        result = CustomAnnotationStage()._process(base_context)
+
+        annotations = result.current_dataframe["Custom_Annotation"]
+        assert "Custom_Annotation" in result.current_dataframe.columns
+        assert "InGeneList=repeat_review_genes" in annotations.iloc[0]
+        assert annotations.iloc[1] == ""
 
 
 class TestInheritanceAnalysisStage:

--- a/tests/unit/stages/test_output_stages.py
+++ b/tests/unit/stages/test_output_stages.py
@@ -54,6 +54,17 @@ class TestVariantIdentifierStage:
         assert variant_ids[1].startswith("var_0002_")
         assert variant_ids[2].startswith("var_0003_")
 
+    def test_adds_custom_annotation_column_for_canonical_annotation_keys(self, context):
+        """Test canonical annotation keys add Custom_Annotation."""
+        context.config["annotate_bed_files"] = ["regions.bed"]
+        context.config["annotate_gene_lists"] = ["genes.txt"]
+        context.config["annotate_bed"] = []
+        context.config["annotate_gene_list"] = []
+
+        result = VariantIdentifierStage()(context)
+
+        assert "Custom_Annotation" in result.current_dataframe.columns
+
     def test_dependencies(self):
         """Test stage dependencies."""
         stage = VariantIdentifierStage()

--- a/tests/unit/stages/test_output_stages.py
+++ b/tests/unit/stages/test_output_stages.py
@@ -65,6 +65,16 @@ class TestVariantIdentifierStage:
 
         assert "Custom_Annotation" in result.current_dataframe.columns
 
+    def test_custom_annotation_detection_does_not_mutate_config(self, context):
+        """Custom annotation column detection must not rewrite config aliases."""
+        context.config = {"annotate_bed": "regions.bed"}
+        original_config = context.config.copy()
+
+        result = VariantIdentifierStage()(context)
+
+        assert "Custom_Annotation" in result.current_dataframe.columns
+        assert context.config == original_config
+
     def test_dependencies(self):
         """Test stage dependencies."""
         stage = VariantIdentifierStage()

--- a/tests/unit/stages/test_setup_stages.py
+++ b/tests/unit/stages/test_setup_stages.py
@@ -222,6 +222,36 @@ class TestAnnotationConfigLoadingStage:
         assert len(result.annotation_configs["bed_files"]) == 1
         assert len(result.annotation_configs["gene_lists"]) == 1
 
+    def test_annotation_loading_from_canonical_keys(self, context):
+        """Canonical annotation keys must load into annotation_configs."""
+        bed_file = context.config["annotate_bed"][0]
+        gene_list = context.config["annotate_gene_list"][0]
+        context.config["annotate_bed"] = []
+        context.config["annotate_gene_list"] = []
+        context.config["annotate_bed_files"] = [bed_file]
+        context.config["annotate_gene_lists"] = [gene_list]
+
+        stage = AnnotationConfigLoadingStage()
+        result = stage(context)
+
+        assert result.annotation_configs["bed_files"] == [bed_file]
+        assert result.annotation_configs["gene_lists"] == [gene_list]
+
+    def test_checkpoint_skip_restores_canonical_annotation_keys(self, context):
+        """Checkpoint skip restore must use canonical annotation keys."""
+        bed_file = context.config["annotate_bed"][0]
+        gene_list = context.config["annotate_gene_list"][0]
+        context.config["annotate_bed"] = []
+        context.config["annotate_gene_list"] = []
+        context.config["annotate_bed_files"] = [bed_file]
+        context.config["annotate_gene_lists"] = [gene_list]
+
+        stage = AnnotationConfigLoadingStage()
+        result = stage._handle_checkpoint_skip(context)
+
+        assert result.annotation_configs["bed_files"] == [bed_file]
+        assert result.annotation_configs["gene_lists"] == [gene_list]
+
     def test_json_gene_annotation(self, context):
         """Test JSON gene annotation loading."""
         # Create temp JSON file

--- a/tests/unit/test_annotation_config_normalization.py
+++ b/tests/unit/test_annotation_config_normalization.py
@@ -95,3 +95,11 @@ def test_filters_empty_items_from_annotation_lists():
 
     assert result["annotate_bed_files"] == ["regions.bed"]
     assert result["annotate_gene_lists"] == ["genes.txt"]
+
+
+def test_treats_mapping_annotation_value_as_scalar_not_iterable_keys():
+    cfg = {"annotate_bed_files": {"regions.bed": "repeat_region"}}
+
+    result = normalize_annotation_config(cfg)
+
+    assert result["annotate_bed_files"] == ["{'regions.bed': 'repeat_region'}"]

--- a/tests/unit/test_annotation_config_normalization.py
+++ b/tests/unit/test_annotation_config_normalization.py
@@ -1,0 +1,97 @@
+"""Tests for annotation config key normalization."""
+
+from variantcentrifuge.config import normalize_annotation_config
+
+
+def test_normalizes_canonical_bed_key_to_all_bed_aliases():
+    cfg = {"annotate_bed_files": ["regions.bed"]}
+
+    result = normalize_annotation_config(cfg)
+
+    assert result is cfg
+    assert result["annotate_bed_files"] == ["regions.bed"]
+    assert result["annotate_bed"] == ["regions.bed"]
+
+
+def test_normalizes_legacy_bed_key_to_canonical_key():
+    cfg = {"annotate_bed": "regions.bed"}
+
+    result = normalize_annotation_config(cfg)
+
+    assert result["annotate_bed_files"] == ["regions.bed"]
+    assert result["annotate_bed"] == ["regions.bed"]
+
+
+def test_empty_legacy_bed_key_does_not_mask_canonical_bed_key():
+    cfg = {"annotate_bed": [], "annotate_bed_files": ["regions.bed"]}
+
+    result = normalize_annotation_config(cfg)
+
+    assert result["annotate_bed_files"] == ["regions.bed"]
+    assert result["annotate_bed"] == ["regions.bed"]
+
+
+def test_normalizes_canonical_gene_list_key_to_all_gene_list_aliases():
+    cfg = {"annotate_gene_lists": ["genes.txt"]}
+
+    result = normalize_annotation_config(cfg)
+
+    assert result["annotate_gene_lists"] == ["genes.txt"]
+    assert result["annotate_gene_list_files"] == ["genes.txt"]
+    assert result["annotate_gene_list"] == ["genes.txt"]
+
+
+def test_normalizes_legacy_gene_list_key_to_canonical_key():
+    cfg = {"annotate_gene_list": "genes.txt"}
+
+    result = normalize_annotation_config(cfg)
+
+    assert result["annotate_gene_lists"] == ["genes.txt"]
+    assert result["annotate_gene_list_files"] == ["genes.txt"]
+    assert result["annotate_gene_list"] == ["genes.txt"]
+
+
+def test_normalizes_gene_list_files_key_to_canonical_key():
+    cfg = {"annotate_gene_list_files": ["genes.txt"]}
+
+    result = normalize_annotation_config(cfg)
+
+    assert result["annotate_gene_lists"] == ["genes.txt"]
+    assert result["annotate_gene_list_files"] == ["genes.txt"]
+    assert result["annotate_gene_list"] == ["genes.txt"]
+
+
+def test_empty_legacy_gene_list_key_does_not_mask_canonical_gene_list_key():
+    cfg = {
+        "annotate_gene_list": [],
+        "annotate_gene_list_files": [],
+        "annotate_gene_lists": ["genes.txt"],
+    }
+
+    result = normalize_annotation_config(cfg)
+
+    assert result["annotate_gene_lists"] == ["genes.txt"]
+    assert result["annotate_gene_list_files"] == ["genes.txt"]
+    assert result["annotate_gene_list"] == ["genes.txt"]
+
+
+def test_missing_annotation_keys_are_normalized_to_empty_lists():
+    result = normalize_annotation_config({})
+
+    assert result["annotate_bed_files"] == []
+    assert result["annotate_bed"] == []
+    assert result["annotate_gene_lists"] == []
+    assert result["annotate_gene_list_files"] == []
+    assert result["annotate_gene_list"] == []
+
+
+def test_filters_empty_items_from_annotation_lists():
+    cfg = {
+        "annotate_bed_files": ["regions.bed", "", None],
+        "annotate_gene_lists": ["genes.txt", "", None],
+    }
+
+    result = normalize_annotation_config(cfg)
+
+    assert result["annotate_bed_files"] == ["regions.bed"]
+    assert result["annotate_gene_lists"] == ["genes.txt"]

--- a/variantcentrifuge/checkpoint.py
+++ b/variantcentrifuge/checkpoint.py
@@ -17,7 +17,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from functools import wraps
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from .config import normalize_annotation_config
 
@@ -193,6 +193,65 @@ class PipelineState:
 
     STATE_FILE_NAME = ".variantcentrifuge_state.json"
     STATE_VERSION = "1.0"
+    _RELEVANT_CONFIG_KEYS: ClassVar[tuple[str, ...]] = (
+        "gene_name",
+        "gene_file",
+        "vcf_file",
+        "output_file",
+        "preset",
+        "filters",
+        "fields",
+        "threads",
+        "no_replacement",
+        "late_filtering",
+        "chunk_size",
+        "samples_file",
+        "bcftools_prefilter",
+        "final_filter",
+        "scoring_config_path",
+        "ped",
+        "inheritance_mode",
+        "annotate_bed_files",
+        "annotate_gene_lists",
+        "annotate_json_genes",
+    )
+    _CANONICAL_ANNOTATION_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "annotate_bed_files",
+            "annotate_gene_lists",
+        }
+    )
+    _LEGACY_RELEVANT_CONFIG_KEYS: ClassVar[tuple[str, ...]] = (
+        "gene_name",
+        "gene_file",
+        "vcf_file",
+        "output_file",
+        "preset",
+        "filters",
+        "fields",
+        "threads",
+        "no_replacement",
+        "late_filtering",
+        "chunk_size",
+        "samples_file",
+        "bcftools_prefilter",
+        "final_filter",
+        "scoring_config_path",
+        "ped",
+        "inheritance_mode",
+        "annotate_bed",
+        "annotate_gene_list",
+        "annotate_json_genes",
+    )
+    _ANNOTATION_ALIAS_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "annotate_bed",
+            "annotate_bed_files",
+            "annotate_gene_list",
+            "annotate_gene_list_files",
+            "annotate_gene_lists",
+        }
+    )
 
     def __init__(self, output_dir: str, enable_checksum: bool = False):
         """Initialize pipeline state manager.
@@ -321,8 +380,8 @@ class PipelineState:
             return False
 
         # Check configuration hash
-        current_hash = self._hash_configuration(configuration)
-        if self.state.get("configuration_hash") != current_hash:
+        current_hashes = self._resume_configuration_hashes(configuration)
+        if self.state.get("configuration_hash") not in current_hashes:
             logger.warning("Configuration has changed, cannot resume")
             return False
 
@@ -807,49 +866,61 @@ class PipelineState:
         """Create a hash of the configuration for change detection."""
         config = normalize_annotation_config(config.copy())
 
-        # Select relevant configuration keys that affect pipeline behavior
-        relevant_keys = [
-            "gene_name",
-            "gene_file",
-            "vcf_file",
-            "output_file",
-            "preset",
-            "filters",
-            "fields",
-            "threads",
-            "no_replacement",
-            "late_filtering",
-            "chunk_size",
-            "samples_file",
-            "bcftools_prefilter",
-            "final_filter",
-            "scoring_config_path",
-            "ped",
-            "inheritance_mode",
-            "annotate_bed",
-            "annotate_bed_files",
-            "annotate_gene_list",
-            "annotate_gene_list_files",
-            "annotate_gene_lists",
-            "annotate_json_genes",
-        ]
-        annotation_alias_keys = {
-            "annotate_bed",
-            "annotate_bed_files",
-            "annotate_gene_list",
-            "annotate_gene_list_files",
-            "annotate_gene_lists",
-        }
-
         relevant_config = {
             k: v
             for k, v in config.items()
-            if k in relevant_keys and v is not None and not (k in annotation_alias_keys and not v)
+            if k in self._RELEVANT_CONFIG_KEYS
+            and v is not None
+            and not (k in self._CANONICAL_ANNOTATION_KEYS and not v)
         }
 
         # Sort for consistent hashing
         config_str = json.dumps(relevant_config, sort_keys=True)
         return hashlib.sha256(config_str.encode()).hexdigest()
+
+    def _resume_configuration_hashes(self, config: dict[str, Any]) -> set[str]:
+        """Return current and legacy-equivalent config hashes accepted for resume."""
+        hashes = {self._hash_configuration(config)}
+        hashes.update(
+            self._hash_legacy_configuration(candidate)
+            for candidate in self._legacy_annotation_equivalent_configs(config)
+        )
+        return hashes
+
+    def _hash_legacy_configuration(self, config: dict[str, Any]) -> str:
+        """Create the pre-normalization checkpoint hash for compatibility."""
+        relevant_config = {
+            k: v
+            for k, v in config.items()
+            if k in self._LEGACY_RELEVANT_CONFIG_KEYS and v is not None
+        }
+
+        config_str = json.dumps(relevant_config, sort_keys=True)
+        return hashlib.sha256(config_str.encode()).hexdigest()
+
+    def _legacy_annotation_equivalent_configs(self, config: dict[str, Any]) -> list[dict[str, Any]]:
+        """Build legacy-key configs that represent the normalized annotation behavior."""
+        normalized = normalize_annotation_config(config.copy())
+        base_config = config.copy()
+        for key in self._ANNOTATION_ALIAS_KEYS:
+            base_config.pop(key, None)
+
+        bed_files = normalized.get("annotate_bed_files", [])
+        gene_lists = normalized.get("annotate_gene_lists", [])
+
+        bed_options = [{"annotate_bed": bed_files}] if bed_files else [{}, {"annotate_bed": []}]
+        gene_options = (
+            [{"annotate_gene_list": gene_lists}] if gene_lists else [{}, {"annotate_gene_list": []}]
+        )
+
+        legacy_configs = []
+        for bed_option in bed_options:
+            for gene_option in gene_options:
+                candidate = base_config.copy()
+                candidate.update(bed_option)
+                candidate.update(gene_option)
+                legacy_configs.append(candidate)
+        return legacy_configs
 
     def cleanup_stale_stages(self) -> None:
         """Clean up stages that were left in 'running' state from previous pipeline runs."""

--- a/variantcentrifuge/checkpoint.py
+++ b/variantcentrifuge/checkpoint.py
@@ -833,8 +833,19 @@ class PipelineState:
             "annotate_gene_lists",
             "annotate_json_genes",
         ]
+        annotation_alias_keys = {
+            "annotate_bed",
+            "annotate_bed_files",
+            "annotate_gene_list",
+            "annotate_gene_list_files",
+            "annotate_gene_lists",
+        }
 
-        relevant_config = {k: v for k, v in config.items() if k in relevant_keys and v is not None}
+        relevant_config = {
+            k: v
+            for k, v in config.items()
+            if k in relevant_keys and v is not None and not (k in annotation_alias_keys and not v)
+        }
 
         # Sort for consistent hashing
         config_str = json.dumps(relevant_config, sort_keys=True)

--- a/variantcentrifuge/checkpoint.py
+++ b/variantcentrifuge/checkpoint.py
@@ -19,6 +19,8 @@ from functools import wraps
 from pathlib import Path
 from typing import Any
 
+from .config import normalize_annotation_config
+
 logger = logging.getLogger("variantcentrifuge")
 
 
@@ -803,6 +805,8 @@ class PipelineState:
 
     def _hash_configuration(self, config: dict[str, Any]) -> str:
         """Create a hash of the configuration for change detection."""
+        config = normalize_annotation_config(config.copy())
+
         # Select relevant configuration keys that affect pipeline behavior
         relevant_keys = [
             "gene_name",
@@ -823,7 +827,10 @@ class PipelineState:
             "ped",
             "inheritance_mode",
             "annotate_bed",
+            "annotate_bed_files",
             "annotate_gene_list",
+            "annotate_gene_list_files",
+            "annotate_gene_lists",
             "annotate_json_genes",
         ]
 

--- a/variantcentrifuge/cli.py
+++ b/variantcentrifuge/cli.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from .config import load_config
+from .config import load_config, normalize_annotation_config
 from .pipeline import run_pipeline
 from .validators import (
     validate_mandatory_parameters,
@@ -1501,6 +1501,7 @@ def main() -> int:
     # Note: args.annotate_gene_list is already handled above as "annotate_gene_list_files"
     # We'll map it to the new unified system
     cfg["annotate_gene_lists"] = args.annotate_gene_list
+    normalize_annotation_config(cfg)
 
     # Validate unified annotation arguments
     if args.annotate_json_genes and not args.json_gene_mapping:

--- a/variantcentrifuge/config.py
+++ b/variantcentrifuge/config.py
@@ -14,6 +14,7 @@ config.json from the package installation directory.
 
 import json
 import os
+from collections.abc import Iterable
 from typing import Any
 
 
@@ -60,4 +61,62 @@ def load_config(config_file: str | None = None) -> dict[str, Any]:
         raise ValueError(
             f"Configuration file must contain a JSON object, got {type(config).__name__}"
         )
+    return config
+
+
+def _annotation_value_as_list(value: Any) -> list[str]:
+    """Normalize annotation config values to a list of non-empty strings."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        stripped = value.strip()
+        return [stripped] if stripped else []
+    if isinstance(value, Iterable):
+        normalized = []
+        for item in value:
+            if item is None:
+                continue
+            item_str = str(item).strip()
+            if item_str:
+                normalized.append(item_str)
+        return normalized
+    item_str = str(value).strip()
+    return [item_str] if item_str else []
+
+
+def _first_non_empty_annotation_value(config: dict[str, Any], keys: list[str]) -> list[str]:
+    """Return the first non-empty normalized annotation value for key aliases."""
+    for key in keys:
+        value = _annotation_value_as_list(config.get(key))
+        if value:
+            return value
+    return []
+
+
+def normalize_annotation_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Normalize custom annotation config aliases in-place.
+
+    Canonical internal keys:
+    - annotate_bed_files
+    - annotate_gene_lists
+
+    Compatibility aliases:
+    - annotate_bed
+    - annotate_gene_list
+    - annotate_gene_list_files
+    """
+    bed_files = _first_non_empty_annotation_value(
+        config,
+        ["annotate_bed_files", "annotate_bed"],
+    )
+    gene_lists = _first_non_empty_annotation_value(
+        config,
+        ["annotate_gene_lists", "annotate_gene_list_files", "annotate_gene_list"],
+    )
+
+    config["annotate_bed_files"] = bed_files
+    config["annotate_bed"] = bed_files
+    config["annotate_gene_lists"] = gene_lists
+    config["annotate_gene_list_files"] = gene_lists
+    config["annotate_gene_list"] = gene_lists
     return config

--- a/variantcentrifuge/config.py
+++ b/variantcentrifuge/config.py
@@ -14,7 +14,6 @@ config.json from the package installation directory.
 
 import json
 import os
-from collections.abc import Iterable
 from typing import Any
 
 
@@ -71,9 +70,10 @@ def _annotation_value_as_list(value: Any) -> list[str]:
     if isinstance(value, str):
         stripped = value.strip()
         return [stripped] if stripped else []
-    if isinstance(value, Iterable):
+    if isinstance(value, (list, tuple, set)):
         normalized = []
-        for item in value:
+        items = sorted(value, key=str) if isinstance(value, set) else value
+        for item in items:
             if item is None:
                 continue
             item_str = str(item).strip()

--- a/variantcentrifuge/pipeline.py
+++ b/variantcentrifuge/pipeline.py
@@ -10,7 +10,7 @@ import logging
 from pathlib import Path
 from typing import Literal
 
-from .config import load_config
+from .config import load_config, normalize_annotation_config
 from .gene_bed import normalize_genes
 from .pipeline_core.context import PipelineContext
 from .pipeline_core.runner import PipelineRunner
@@ -148,6 +148,19 @@ def build_pipeline_stages(args: argparse.Namespace) -> list[Stage]:
     # Get config to check for scoring_config_path
     # If args.config is a dict, use it; otherwise check individual args
     config = args.config if hasattr(args, "config") and isinstance(args.config, dict) else {}
+    if isinstance(config, dict):
+        normalize_annotation_config(config)
+
+    annotations_requested = any(
+        [
+            config.get("annotate_bed_files"),
+            config.get("annotate_gene_lists"),
+            config.get("annotate_json_genes"),
+            hasattr(args, "annotate_bed") and args.annotate_bed,
+            hasattr(args, "annotate_gene_list") and args.annotate_gene_list,
+            hasattr(args, "annotate_json_genes") and args.annotate_json_genes,
+        ]
+    )
 
     # Setup stages (can run in parallel)
     # Always add phenotype loading stage - it will skip if no phenotype file is provided
@@ -162,13 +175,7 @@ def build_pipeline_stages(args: argparse.Namespace) -> list[Stage]:
     if hasattr(args, "ped_file") and args.ped_file:
         stages.append(PedigreeLoadingStage())
 
-    if any(
-        [
-            hasattr(args, "annotate_bed") and args.annotate_bed,
-            hasattr(args, "annotate_gene_list") and args.annotate_gene_list,
-            hasattr(args, "annotate_json_genes") and args.annotate_json_genes,
-        ]
-    ):
+    if annotations_requested:
         stages.append(AnnotationConfigLoadingStage())
 
     # Always load samples
@@ -229,13 +236,7 @@ def build_pipeline_stages(args: argparse.Namespace) -> list[Stage]:
     # This stage will automatically activate when use_chunked_processing is set to True
     stages.append(ChunkedAnalysisStage())
 
-    if any(
-        [
-            hasattr(args, "annotate_bed") and args.annotate_bed,
-            hasattr(args, "annotate_gene_list") and args.annotate_gene_list,
-            hasattr(args, "annotate_json_genes") and args.annotate_json_genes,
-        ]
-    ):
+    if annotations_requested:
         stages.append(CustomAnnotationStage())
 
     # Check both args and config for inheritance settings
@@ -372,6 +373,8 @@ def create_stages_from_config(config: dict) -> list[Stage]:
     igv                     IGVReportStage
     ======================= ===========================
     """
+    config = normalize_annotation_config(config.copy())
+
     # Convert config dict to a minimal args namespace for compatibility
     args = argparse.Namespace()
 
@@ -379,8 +382,8 @@ def create_stages_from_config(config: dict) -> list[Stage]:
     args.config = config
     args.scoring_config_path = config.get("scoring_config_path")
     args.ped_file = config.get("ped_file")
-    args.annotate_bed = config.get("annotate_bed", [])
-    args.annotate_gene_list = config.get("annotate_gene_list", [])
+    args.annotate_bed = config.get("annotate_bed_files", [])
+    args.annotate_gene_list = config.get("annotate_gene_lists", [])
     args.annotate_json_genes = config.get("annotate_json_genes", [])
     args.late_filtering = config.get("late_filtering", False)
     args.genotype_filter = config.get("genotype_filter")

--- a/variantcentrifuge/pipeline.py
+++ b/variantcentrifuge/pipeline.py
@@ -147,9 +147,8 @@ def build_pipeline_stages(args: argparse.Namespace) -> list[Stage]:
 
     # Get config to check for scoring_config_path
     # If args.config is a dict, use it; otherwise check individual args
-    config = args.config if hasattr(args, "config") and isinstance(args.config, dict) else {}
-    if isinstance(config, dict):
-        normalize_annotation_config(config)
+    raw_config = args.config if hasattr(args, "config") and isinstance(args.config, dict) else {}
+    config = normalize_annotation_config(raw_config.copy()) if raw_config else {}
 
     annotations_requested = any(
         [

--- a/variantcentrifuge/stages/output_stages.py
+++ b/variantcentrifuge/stages/output_stages.py
@@ -22,6 +22,7 @@ from typing import Any, cast
 
 import pandas as pd
 
+from ..config import normalize_annotation_config
 from ..converter import (
     append_tsv_as_sheet,
     convert_to_excel,
@@ -245,11 +246,13 @@ class VariantIdentifierStage(Stage):
             # Fallback to simple index
             df.insert(0, id_column, [f"var_{i:04d}_0000" for i in range(1, len(df) + 1)])
 
+        normalize_annotation_config(context.config)
+
         # Only add Custom_Annotation column if custom annotations are actually requested
         custom_annotations_requested = any(
             [
-                context.config.get("annotate_bed", []),
-                context.config.get("annotate_gene_list", []),
+                context.config.get("annotate_bed_files", []),
+                context.config.get("annotate_gene_lists", []),
                 context.config.get("annotate_json_genes", []),
             ]
         )

--- a/variantcentrifuge/stages/output_stages.py
+++ b/variantcentrifuge/stages/output_stages.py
@@ -246,14 +246,14 @@ class VariantIdentifierStage(Stage):
             # Fallback to simple index
             df.insert(0, id_column, [f"var_{i:04d}_0000" for i in range(1, len(df) + 1)])
 
-        normalize_annotation_config(context.config)
+        annotation_config = normalize_annotation_config(context.config.copy())
 
         # Only add Custom_Annotation column if custom annotations are actually requested
         custom_annotations_requested = any(
             [
-                context.config.get("annotate_bed_files", []),
-                context.config.get("annotate_gene_lists", []),
-                context.config.get("annotate_json_genes", []),
+                annotation_config.get("annotate_bed_files", []),
+                annotation_config.get("annotate_gene_lists", []),
+                annotation_config.get("annotate_json_genes", []),
             ]
         )
 

--- a/variantcentrifuge/stages/setup_stages.py
+++ b/variantcentrifuge/stages/setup_stages.py
@@ -8,7 +8,7 @@ scoring configurations, and other setup tasks that can run in parallel.
 import logging
 import os
 
-from ..config import load_config
+from ..config import load_config, normalize_annotation_config
 from ..helpers import get_vcf_samples
 from ..ped_reader import read_pedigree
 from ..phenotype import load_phenotypes
@@ -454,9 +454,10 @@ class AnnotationConfigLoadingStage(Stage):
     def _process(self, context: PipelineContext) -> PipelineContext:
         """Load all annotation configurations."""
         annotations = {}
+        normalize_annotation_config(context.config)
 
         # Load BED file annotations
-        bed_files = context.config.get("annotate_bed", [])
+        bed_files = context.config.get("annotate_bed_files", [])
         if bed_files:
             if isinstance(bed_files, str):
                 bed_files = [bed_files]
@@ -464,7 +465,7 @@ class AnnotationConfigLoadingStage(Stage):
             logger.info(f"Configured {len(bed_files)} BED file annotations")
 
         # Load gene list annotations
-        gene_lists = context.config.get("annotate_gene_list", [])
+        gene_lists = context.config.get("annotate_gene_lists", [])
         if gene_lists:
             if isinstance(gene_lists, str):
                 gene_lists = [gene_lists]
@@ -491,9 +492,10 @@ class AnnotationConfigLoadingStage(Stage):
         configurations that would have been loaded during normal execution.
         """
         annotations = {}
+        normalize_annotation_config(context.config)
 
         # Restore BED file annotations
-        bed_files = context.config.get("annotate_bed", [])
+        bed_files = context.config.get("annotate_bed_files", [])
         if bed_files:
             if isinstance(bed_files, str):
                 bed_files = [bed_files]
@@ -501,7 +503,7 @@ class AnnotationConfigLoadingStage(Stage):
             logger.debug(f"Restored {len(bed_files)} BED file annotations (checkpoint skip)")
 
         # Restore gene list annotations
-        gene_lists = context.config.get("annotate_gene_list", [])
+        gene_lists = context.config.get("annotate_gene_lists", [])
         if gene_lists:
             if isinstance(gene_lists, str):
                 gene_lists = [gene_lists]


### PR DESCRIPTION
## Summary
- Normalize custom annotation aliases into canonical BED and gene-list config keys while preserving legacy keys.
- Route normalized annotation config through CLI assembly, stage selection, setup loading, output-column detection, and checkpoint hashing.
- Add regressions for BED, gene-list, config-driven stage activation, checkpoint invalidation/compatibility, and DataFrame-level `Custom_Annotation` behavior.

Fixes #95.

## Test Plan
- [x] `python -m pytest tests/unit/test_annotation_config_normalization.py tests/test_cli_argument_parsing.py::test_cli_annotate_bed_populates_canonical_and_legacy_config_keys tests/test_gene_list_integration.py::test_cli_gene_list_integration tests/unit/stages/test_setup_stages.py::TestAnnotationConfigLoadingStage tests/integration/test_create_stages_from_config.py tests/unit/stages/test_output_stages.py::TestVariantIdentifierStage tests/test_checkpoint.py::TestPipelineState tests/unit/stages/test_analysis_stages.py::TestCustomAnnotationStage -q` (`48 passed`)
- [x] `python -m pytest tests/test_annotator.py tests/test_gene_list_annotation.py tests/test_gene_list_integration.py -q` (`57 passed`)
- [x] `python -m pytest tests/unit/stages/test_setup_stages.py tests/unit/stages/test_analysis_stages.py tests/unit/stages/test_output_stages.py tests/integration/test_create_stages_from_config.py -q` (`120 passed`)
- [x] `git diff --check`

## Notes
- Does not implement issue #94 first-class technical-region boolean columns; this only restores and hardens existing `Custom_Annotation` behavior.
- Existing no-annotation checkpoint hashes are preserved by skipping normalized empty annotation aliases during hash construction.