### PR TITLE
[codex] Fix snpEff genes2bed diagnostics

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [0.17.4] - 2026-05-15
+
+### Fixed
+- Build `snpEff genes2bed` commands with expansion options before genome and gene positional arguments.
+- Capture and propagate stdout/stderr diagnostics from gene BED subprocess failures.
+- Allow `--regions-bed` with `--gene-name all` to use the supplied BED directly.
+
 ## [0.17.3] - 2026-05-15
 
 ### Fixed

--- a/tests/integration/test_pipeline_with_mocked_tools.py
+++ b/tests/integration/test_pipeline_with_mocked_tools.py
@@ -21,9 +21,8 @@ class MockedToolsTestCase:
     @pytest.fixture(autouse=True)
     def setup_mocks(self):
         """Set up mocks for external tools."""
-        self.bcftools_patcher = patch("variantcentrifuge.stages.processing_stages.run_command")
+        self.bcftools_patcher = patch("variantcentrifuge.filters.run_command")
         self.snpeff_patcher = patch("variantcentrifuge.gene_bed.subprocess.run")
-        self.snpsift_patcher = patch("variantcentrifuge.filters.run_command")
         # Patch extract_fields_bcftools (Phase 11: bcftools replaces SnpSift)
         self.extractor_patcher = patch(
             "variantcentrifuge.stages.processing_stages.extract_fields_bcftools"
@@ -31,7 +30,7 @@ class MockedToolsTestCase:
 
         self.mock_bcftools = self.bcftools_patcher.start()
         self.mock_snpeff = self.snpeff_patcher.start()
-        self.mock_snpsift = self.snpsift_patcher.start()
+        self.mock_snpsift = self.mock_bcftools
         self.mock_extractor = self.extractor_patcher.start()
 
         # Configure default behaviors
@@ -41,7 +40,6 @@ class MockedToolsTestCase:
 
         self.bcftools_patcher.stop()
         self.snpeff_patcher.stop()
-        self.snpsift_patcher.stop()
         self.extractor_patcher.stop()
 
     def _configure_tool_mocks(self):
@@ -135,9 +133,13 @@ class MockedToolsTestCase:
 
             return result
 
-        self.mock_bcftools.side_effect = bcftools_side_effect
+        def run_command_side_effect(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and cmd and cmd[0] == "bcftools":
+                return bcftools_side_effect(cmd, *args, **kwargs)
+            return snpsift_side_effect(cmd, *args, **kwargs)
+
+        self.mock_bcftools.side_effect = run_command_side_effect
         self.mock_snpeff.side_effect = snpeff_side_effect
-        self.mock_snpsift.side_effect = snpsift_side_effect
         self.mock_extractor.side_effect = bcftools_extract_side_effect
 
 
@@ -303,10 +305,7 @@ class TestErrorHandling(MockedToolsTestCase):
 
         # Configure bcftools to return error
         def bcftools_error_side_effect(cmd, *args, **kwargs):
-            from variantcentrifuge.utils import CommandError
-
-            # Raise CommandError which is what run_command raises on failure
-            raise CommandError("ERROR: Invalid VCF format")
+            raise RuntimeError("ERROR: Invalid VCF format")
 
         self.mock_bcftools.side_effect = bcftools_error_side_effect
 

--- a/tests/unit/stages/test_processing_stages.py
+++ b/tests/unit/stages/test_processing_stages.py
@@ -62,6 +62,26 @@ class TestGeneBedCreationStage:
         assert result.config["normalized_genes"] == "BRCA1 BRCA2"
         assert result.gene_bed_file == Path("/tmp/genes.bed")
 
+    @patch("variantcentrifuge.stages.processing_stages.get_gene_bed")
+    @patch("variantcentrifuge.stages.processing_stages.normalize_genes")
+    def test_regions_bed_with_all_genes_bypasses_gene_bed_creation(
+        self, mock_normalize, mock_get_bed, context, tmp_path
+    ):
+        """Test that --regions-bed with all genes uses the regions BED directly."""
+        regions_bed = tmp_path / "regions.bed"
+        regions_bed.write_text("chr16\t2088707\t2135898\n")
+        context.config["gene_name"] = "all"
+        context.config["regions_bed"] = str(regions_bed)
+        mock_normalize.return_value = "all"
+
+        stage = GeneBedCreationStage()
+        result = stage(context)
+
+        mock_normalize.assert_called_once_with("all", None, ANY)
+        mock_get_bed.assert_not_called()
+        assert result.config["normalized_genes"] == "all"
+        assert result.gene_bed_file == regions_bed
+
     def test_dependencies(self):
         """Test stage dependencies."""
         stage = GeneBedCreationStage()

--- a/tests/unit/test_gene_bed.py
+++ b/tests/unit/test_gene_bed.py
@@ -1,6 +1,7 @@
 """Unit tests for gene BED creation with merging functionality."""
 
 import os
+import subprocess
 import tempfile
 from unittest.mock import patch
 
@@ -27,6 +28,77 @@ chr20	12345000	12347000	OTHER_GENE
 """
         with open(bed_path, "w") as f:
             f.write(overlapping_bed_content)
+
+    def mock_successful_bed_pipeline(self, cmd, **kwargs):
+        """Mock successful genes2bed, sortBed, and bedtools merge calls."""
+        if "genes2bed" in cmd:
+            output_file = kwargs.get("stdout")
+            if hasattr(output_file, "name"):
+                with open(output_file.name, "w") as f:
+                    f.write("16\t2088707\t2135898\tPKD1\n")
+        elif "sortBed" in cmd or ("bedtools" in cmd and "merge" in cmd):
+            input_file = cmd[cmd.index("-i") + 1]
+            output_file = kwargs.get("stdout")
+            if hasattr(output_file, "name"):
+                with open(input_file) as inf, open(output_file.name, "w") as outf:
+                    outf.write(inf.read())
+
+    @patch("subprocess.run")
+    def test_genes2bed_expansion_option_precedes_reference(self, mock_subprocess, temp_dir):
+        """Test that snpEff genes2bed options are placed before positional arguments."""
+        mock_subprocess.side_effect = self.mock_successful_bed_pipeline
+
+        get_gene_bed(
+            reference="GRCh38.p14",
+            gene_name="PKD1",
+            interval_expand=1000,
+            add_chr=False,
+            output_dir=temp_dir,
+        )
+
+        genes2bed_cmd = next(
+            call.args[0] for call in mock_subprocess.call_args_list if "genes2bed" in call.args[0]
+        )
+        assert genes2bed_cmd == [
+            "snpEff",
+            "-Xmx8g",
+            "genes2bed",
+            "-ud",
+            "1000",
+            "GRCh38.p14",
+            "PKD1",
+        ]
+
+    @patch("subprocess.run")
+    def test_genes2bed_failure_includes_captured_output(self, mock_subprocess, temp_dir):
+        """Test that snpEff failures include stderr and partial stdout in the raised error."""
+
+        def mock_run(cmd, **kwargs):
+            if "genes2bed" in cmd:
+                output_file = kwargs.get("stdout")
+                if hasattr(output_file, "write"):
+                    output_file.write("partial bed output\n")
+                raise subprocess.CalledProcessError(
+                    247, cmd, stderr="SnpEff failed without a BED result"
+                )
+            return None
+
+        mock_subprocess.side_effect = mock_run
+
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            get_gene_bed(
+                reference="GRCh38.p14",
+                gene_name="PKD1",
+                interval_expand=1000,
+                add_chr=False,
+                output_dir=temp_dir,
+            )
+
+        error_message = str(exc_info.value)
+        assert "snpEff genes2bed failed" in error_message
+        assert "exit status 247" in error_message
+        assert "stderr:\nSnpEff failed without a BED result" in error_message
+        assert "stdout:\npartial bed output" in error_message
 
     @patch("subprocess.run")
     def test_bed_merging_removes_overlaps(self, mock_subprocess, temp_dir):

--- a/variantcentrifuge/cli.py
+++ b/variantcentrifuge/cli.py
@@ -62,7 +62,7 @@ def create_parser() -> argparse.ArgumentParser:
     )
     general_group.add_argument(
         "--log-level",
-        choices=["DEBUG", "INFO", "WARN", "ERROR"],
+        choices=["DEBUG", "INFO", "WARN", "WARNING", "ERROR"],
         default="INFO",
         help="Set the logging level",
     )
@@ -130,7 +130,8 @@ def create_parser() -> argparse.ArgumentParser:
         "--regions-bed",
         help=(
             "BED file to restrict variant extraction to specified regions (e.g., capture kit BED). "
-            "The gene BED is intersected with this file before variant extraction."
+            "The gene BED is intersected with this file before variant extraction; with "
+            "--gene-name all, the regions BED is used directly."
         ),
         default=None,
     )
@@ -1082,7 +1083,7 @@ def main() -> int:
         status_parser.add_argument("--show-checkpoint-status", action="store_true")
         status_parser.add_argument("--output-dir", default="output", help="Output directory")
         status_parser.add_argument(
-            "--log-level", choices=["DEBUG", "INFO", "WARN", "ERROR"], default="INFO"
+            "--log-level", choices=["DEBUG", "INFO", "WARN", "WARNING", "ERROR"], default="INFO"
         )
         status_parser.add_argument(
             "-c", "--config", help="Path to configuration file", default=None
@@ -1094,6 +1095,7 @@ def main() -> int:
             "DEBUG": logging.DEBUG,
             "INFO": logging.INFO,
             "WARN": logging.WARNING,
+            "WARNING": logging.WARNING,
             "ERROR": logging.ERROR,
         }
         logging.getLogger("variantcentrifuge").setLevel(log_level_map[status_args.log_level])
@@ -1117,6 +1119,7 @@ def main() -> int:
         "DEBUG": logging.DEBUG,
         "INFO": logging.INFO,
         "WARN": logging.WARNING,
+        "WARNING": logging.WARNING,
         "ERROR": logging.ERROR,
     }
     logging.getLogger("variantcentrifuge").setLevel(log_level_map[args.log_level])

--- a/variantcentrifuge/gene_bed.py
+++ b/variantcentrifuge/gene_bed.py
@@ -19,6 +19,78 @@ import tempfile
 
 logger = logging.getLogger("variantcentrifuge")
 
+_COMMAND_OUTPUT_PREVIEW_CHARS = 4000
+
+
+class GeneBedCommandError(subprocess.CalledProcessError):
+    """CalledProcessError that includes captured command output in its message."""
+
+    def __init__(
+        self,
+        returncode: int,
+        cmd: list[str],
+        *,
+        stdout: str | None = None,
+        stderr: str | None = None,
+        description: str,
+    ) -> None:
+        super().__init__(returncode, cmd, output=stdout, stderr=stderr)
+        self.description = description
+
+    def __str__(self) -> str:
+        parts = [f"{self.description} failed: {super().__str__()}"]
+        if self.stderr:
+            parts.append(f"stderr:\n{self.stderr}")
+        if self.stdout:
+            parts.append(f"stdout:\n{self.stdout}")
+        return "\n".join(parts)
+
+
+def _preview_text(text: str | None, max_chars: int = _COMMAND_OUTPUT_PREVIEW_CHARS) -> str | None:
+    """Return a bounded preview of command output."""
+    if not text:
+        return None
+    text = text.strip()
+    if not text:
+        return None
+    if len(text) <= max_chars:
+        return text
+    return f"{text[:max_chars]}... [truncated]"
+
+
+def _preview_file(path: str, max_chars: int = _COMMAND_OUTPUT_PREVIEW_CHARS) -> str | None:
+    """Return a bounded preview of a text file if it contains any output."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            return _preview_text(handle.read(max_chars + 1), max_chars=max_chars)
+    except OSError:
+        return None
+
+
+def _run_command_to_file(cmd: list[str], output_path: str, description: str) -> None:
+    """Run a command with stdout redirected to a file and stderr captured for diagnostics."""
+    try:
+        with open(output_path, "w", encoding="utf-8") as out_f:
+            subprocess.run(
+                cmd,
+                stdout=out_f,
+                stderr=subprocess.PIPE,
+                check=True,
+                text=True,
+            )
+    except subprocess.CalledProcessError as e:
+        stdout_preview = _preview_file(output_path)
+        stderr_preview = _preview_text(e.stderr)
+        error = GeneBedCommandError(
+            e.returncode,
+            e.cmd,
+            stdout=stdout_preview,
+            stderr=stderr_preview,
+            description=description,
+        )
+        logger.error("%s", error)
+        raise error from e
+
 
 def normalize_genes(
     gene_name_str: str | None, gene_file_str: str | None, logger: logging.Logger
@@ -154,29 +226,27 @@ def get_gene_bed(
     os.close(bed_fd)
 
     try:
-        cmd = ["snpEff", "-Xmx8g", "genes2bed", reference, *gene_args]
+        cmd = ["snpEff", "-Xmx8g", "genes2bed"]
         if interval_expand > 0:
             cmd.extend(["-ud", str(interval_expand)])
+        cmd.extend([reference, *gene_args])
 
         logger.info("Running: %s", " ".join(cmd))
-        with open(bed_path, "w", encoding="utf-8") as out_f:
-            subprocess.run(cmd, stdout=out_f, check=True, text=True)
+        _run_command_to_file(cmd, bed_path, "snpEff genes2bed")
         logger.debug("snpEff genes2bed completed, BED file at %s", bed_path)
 
         # Sort the BED file
         sorted_bed = bed_path + ".sorted"
         sort_cmd = ["sortBed", "-i", bed_path]
         logger.debug("Sorting BED file with: %s", " ".join(sort_cmd))
-        with open(sorted_bed, "w", encoding="utf-8") as out_f:
-            subprocess.run(sort_cmd, stdout=out_f, check=True, text=True)
+        _run_command_to_file(sort_cmd, sorted_bed, "sortBed")
         logger.debug("BED sorting completed, sorted file at %s", sorted_bed)
 
         # Merge overlapping intervals to prevent duplicate variant extraction
         merged_bed = sorted_bed + ".merged"
         merge_cmd = ["bedtools", "merge", "-i", sorted_bed]
         logger.debug("Merging overlapping intervals with: %s", " ".join(merge_cmd))
-        with open(merged_bed, "w", encoding="utf-8") as out_f:
-            subprocess.run(merge_cmd, stdout=out_f, check=True, text=True)
+        _run_command_to_file(merge_cmd, merged_bed, "bedtools merge")
         logger.debug("BED merging completed, merged file at %s", merged_bed)
 
         # Clean up intermediate files

--- a/variantcentrifuge/stages/processing_stages.py
+++ b/variantcentrifuge/stages/processing_stages.py
@@ -101,6 +101,15 @@ class GeneBedCreationStage(Stage):
             reference = context.config.get("reference", "GRCh37.75")
             interval_expand = context.config.get("interval_expand", 0)
             add_chr = context.config.get("add_chr", True)
+            regions_bed = context.config.get("regions_bed")
+
+            if regions_bed and normalized_genes.lower().strip() == "all":
+                context.gene_bed_file = validate_file_exists(regions_bed, self.name)
+                logger.info(
+                    "Using regions BED directly because gene selection is 'all': %s",
+                    context.gene_bed_file,
+                )
+                return context
 
             logger.info(f"Creating BED file for genes: {normalized_genes}")
 
@@ -120,21 +129,26 @@ class GeneBedCreationStage(Stage):
             try:
                 bed_file = create_bed()
             except subprocess.CalledProcessError as e:
+                # Check if it's a gene not found error before the broader tool-not-found case.
+                if "not found in database" in str(e):
+                    snpeff_reason = getattr(e, "stderr", None) or str(e)
+                    raise FileFormatError(
+                        normalized_genes,
+                        (
+                            f"valid gene names for {reference}; "
+                            f"snpEff genes2bed reported: {snpeff_reason.strip()}"
+                        ),
+                        self.name,
+                    ) from e
                 # Check if it's a tool not found error
                 if "snpEff" in str(e) and ("not found" in str(e) or "No such file" in str(e)):
                     raise ToolNotFoundError("snpEff", self.name) from e
-                # Check if it's a gene not found error
-                if "not found in database" in str(e):
-                    raise FileFormatError(
-                        normalized_genes, f"valid gene names for {reference}", self.name
-                    ) from e
                 raise
 
             context.gene_bed_file = Path(bed_file)
             logger.info(f"Created BED file: {bed_file}")
 
             # Region restriction: intersect gene BED with restriction BED
-            regions_bed = context.config.get("regions_bed")
             if regions_bed:
                 context.gene_bed_file = self._intersect_with_restriction_bed(
                     context.gene_bed_file, regions_bed, context

--- a/variantcentrifuge/version.py
+++ b/variantcentrifuge/version.py
@@ -6,4 +6,4 @@ To update the version, change __version__ below. All other references to the ver
 throughout the codebase should import it from here.
 """
 
-__version__ = "0.17.3"
+__version__ = "0.17.4"


### PR DESCRIPTION
## Summary

Fixes #98.

- build `snpEff genes2bed` commands with command options before genome/gene positional arguments
- capture and propagate stderr plus partial stdout for gene BED subprocess failures
- preserve SnpEff gene-not-found details when translating failures at the processing stage
- allow `--regions-bed` with `--gene-name all` to bypass SnpEff gene BED creation and use the supplied BED directly
- accept `--log-level WARNING` as an alias for `WARN`
- bump release version to `0.17.4` and document the fix in the changelog

## Validation

- `python -c "import variantcentrifuge; print(variantcentrifuge.__version__)"` -> `0.17.4`
- `python -m ruff format variantcentrifuge/ tests/`
- `python -m ruff check variantcentrifuge/ tests/` -> pass
- `python -m mypy variantcentrifuge/` -> pass, 85 source files
- `python -m pytest tests/unit/test_gene_bed.py tests/unit/stages/test_processing_stages.py tests/integration/test_pipeline_with_mocked_tools.py -q` -> 47 passed, 3 warnings
- `python -m pytest -m "not slow and not integration" tests/ --tb=short -q` -> 2116 passed, 3 skipped, 136 deselected, 57 warnings

## Notes

A full `python -m pytest tests/` run was attempted before narrowing to the normal suite. It is benchmark-heavy and reported unrelated broad integration failures in gene burden/scoring areas (`8 failed, 2237 passed, 10 skipped`). The normal CI-style suite above passed on this branch.