### PR TITLE
Add score-column variant weights for association tests

### DIFF
--- a/docs/source/configuration.md
+++ b/docs/source/configuration.md
@@ -32,6 +32,13 @@ Configuration options with default values:
 - **`gene_burden_mode`** (`str`) - "samples" or "alleles". *Default: "alleles"*
 - **`correction_method`** (`str`) - "fdr" or "bonferroni" for multiple testing correction. *Default: "fdr"*
 
+### Association Score-Column Weights
+
+For score-column variant weights, set `association.variant_weights` to
+`score_column` and set `association.variant_weight_column` to the numeric
+per-variant column name. See the association testing guide for normalization
+parameters.
+
 ### IGV Integration
 
 - **`igv_enabled`** (`bool`) - Enable IGV.js integration. *Default: false*

--- a/docs/source/guides/association_testing.md
+++ b/docs/source/guides/association_testing.md
@@ -475,6 +475,7 @@ by upweighting likely pathogenic variants.
 | CADD | `cadd` | Beta(MAF) × min(CADD_phred / 40, 1.0); requires `CADD_phred` or `dbNSFP_CADD_phred` |
 | REVEL | `revel` | Beta(MAF) × REVEL_score [0,1]; requires `REVEL_score` or `dbNSFP_REVEL_score` |
 | Combined | `combined` | Beta(MAF) × functional score; prefers CADD, falls back to REVEL |
+| Score column | `column:<name>` or `score_column` | Beta(MAF) × any numeric per-variant score column, or raw score-only weights |
 
 ### CLI Flags
 
@@ -485,6 +486,60 @@ by upweighting likely pathogenic variants.
 
 `--variant-weight-params` accepts a JSON string for scheme-specific tuning. Current supported
 parameter: `cadd_cap` (float, default 40.0) — cap CADD phred score before normalisation.
+
+### Score-Column Variant Weights
+
+Variant-level weights affect each variant's contribution to burden scores and
+SKAT kernels. They are separate from gene-level FDR prior weights, which affect
+multiple-testing correction only.
+
+Use `column:<name>` to reference any numeric per-variant column already present
+in the association input DataFrame:
+
+```bash
+--perform-association \
+--association-tests logistic_burden,skat \
+--variant-weights column:nephro_candidate_score \
+--variant-weight-params '{"score_min":0,"score_max":10,"floor":0.1,"combine_with_beta":true}'
+```
+
+The equivalent friendly form is:
+
+```bash
+--perform-association \
+--association-tests logistic_burden,skat \
+--variant-weights score_column \
+--variant-weight-column nephro_candidate_score \
+--variant-weight-params '{"score_min":0,"score_max":10,"floor":0.1,"combine_with_beta":true}'
+```
+
+Score-column parameters:
+
+| Parameter | Default | Meaning |
+| --- | --- | --- |
+| `score_min` | `null` | Lower bound for explicit linear normalization. |
+| `score_max` | `null` | Upper bound for explicit linear normalization. |
+| `floor` | `0.0` | Lower bound after clipping finite normalized scores. |
+| `ceiling` | `1.0` | Upper bound after clipping finite normalized scores. |
+| `combine_with_beta` | `true` | Multiply the functional score by `Beta(MAF; beta_a,beta_b)`. |
+| `missing` | `null` | `neutral` in Beta-combined mode, `floor` in raw score-only mode. |
+| `beta_a` | `1.0` | Beta alpha used when `combine_with_beta=true`. |
+| `beta_b` | `25.0` | Beta beta used when `combine_with_beta=true`. |
+
+When `combine_with_beta=false`, the normalized score itself is the final variant
+weight. In that raw score-only mode, `missing="neutral"` is invalid because
+there is no multiplicative Beta baseline.
+
+Python SKAT, SKAT-O, and ACAT-V use the same resolved weight vector as burden
+tests. For `beta:*`, Python SKAT preserves its historical MAF source:
+`geno.mean(axis=0) / 2.0` after genotype imputation. Python SKAT now honors
+`cadd`, `revel`, and `combined`; earlier versions silently reduced those
+schemes to Beta-only weights in SKAT.
+
+Fisher exact tests ignore variant weights because they use collapsed contingency
+tables. COAST uses its own ordered allelic-series category weights. The
+deprecated R SKAT backend supports only `beta:a,b` and `uniform`; use the
+default Python backend for score-column or functional weights.
 
 ### Fallback Behaviour for Missing Annotations
 
@@ -756,8 +811,14 @@ Use this for reproducible analyses or when parameters are too numerous for the c
     "pca_file": "ancestry.eigenvec",
     "pca_components": 10,
 
-    "variant_weights": "beta:1,25",
-    "variant_weight_params": {"cadd_cap": 40.0},
+    "variant_weights": "score_column",
+    "variant_weight_column": "nephro_candidate_score",
+    "variant_weight_params": {
+      "score_min": 0,
+      "score_max": 10,
+      "floor": 0.1,
+      "combine_with_beta": true
+    },
 
     "coast_weights": [1, 2, 3],
 
@@ -798,7 +859,8 @@ Use this for reproducible analyses or when parameters are too numerous for the c
 | `pca_file` | str | `null` | Pre-computed PCA file (PLINK .eigenvec, AKT, or generic TSV) |
 | `pca_tool` | str | `null` | `"akt"` to invoke AKT as subprocess |
 | `pca_components` | int | `10` | Number of PCs to include (warn if >20) |
-| `variant_weights` | str | `"beta:1,25"` | Weight scheme: `beta:a,b`, `uniform`, `cadd`, `revel`, `combined` |
+| `variant_weights` | str | `"beta:1,25"` | Weight scheme: `beta:a,b`, `uniform`, `cadd`, `revel`, `combined`, `column:<name>`, `score_column` |
+| `variant_weight_column` | str or null | `null` | Score column used when `variant_weights` is `score_column` |
 | `variant_weight_params` | dict | `null` | Extra weight params, e.g. `{"cadd_cap": 30}` |
 | `coast_weights` | list of float | `[1,2,3]` | COAST category weights: `[BMV, DMV, PTV]` |
 | `gene_prior_weights` | str | `null` | Path to gene-weight TSV for weighted FDR correction |

--- a/docs/source/guides/association_testing.md
+++ b/docs/source/guides/association_testing.md
@@ -484,8 +484,10 @@ by upweighting likely pathogenic variants.
 --variant-weight-params '{"cadd_cap":30}'  # JSON string with extra parameters
 ```
 
-`--variant-weight-params` accepts a JSON string for scheme-specific tuning. Current supported
-parameter: `cadd_cap` (float, default 40.0) — cap CADD phred score before normalisation.
+`--variant-weight-params` accepts a JSON object for scheme-specific tuning.
+Supported keys depend on the selected weight scheme. For CADD-based schemes,
+`cadd_cap` (float, default 40.0) caps the CADD phred score before
+normalisation. For score-column weights, use the parameters in the table below.
 
 ### Score-Column Variant Weights
 

--- a/docs/superpowers/plans/2026-05-15-score-column-variant-weights.md
+++ b/docs/superpowers/plans/2026-05-15-score-column-variant-weights.md
@@ -1331,8 +1331,6 @@ def test_stage_passes_score_column_to_lazy_builder(monkeypatch, tmp_path):
 
     builder = captured_gene_data[0]["_genotype_matrix_builder"]
     assert builder.score_column == "nephro_candidate_score"
-    assert builder.cadd_column == "dbNSFP_CADD_phred"
-    assert builder.revel_column == "dbNSFP_REVEL_score"
     assert builder.effect_column == "ANN_0__EFFECT"
 
 
@@ -2055,10 +2053,17 @@ burden = geno @ weights
 
 - [ ] **Step 5: Update existing backend tests that call `test_gene()`**
 
-In `tests/unit/test_skat_python_backend.py`, replace calls that pass:
+In `tests/unit/test_skat_python_backend.py`, replace calls that pass a Beta tuple
+either by keyword or positionally:
 
 ```python
 weights_beta=(1.0, 25.0)
+```
+
+or:
+
+```python
+backend.test_gene("GENE1", genotype_matrix, null_model, "SKAT", (1.0, 25.0))
 ```
 
 with:

--- a/tests/test_cli_argument_parsing.py
+++ b/tests/test_cli_argument_parsing.py
@@ -10,6 +10,8 @@ of the duplicate argument parser bug and ensure all critical parameters work.
 
 import subprocess
 
+import pytest
+
 
 def test_cli_annotate_bed_populates_canonical_and_legacy_config_keys(monkeypatch, tmp_path):
     from variantcentrifuge import cli as cli_module
@@ -62,6 +64,118 @@ def test_transcript_filtering_parameters_are_documented():
     assert "MANE" in help_text
     assert "GRCh37" in help_text
     assert "RefSeq Select" in help_text
+
+
+def test_variant_weight_column_cli_populates_config(monkeypatch, tmp_path):
+    from variantcentrifuge import cli as cli_module
+
+    captured_configs = []
+
+    def fake_run_pipeline(args):
+        captured_configs.append(args.config.copy())
+
+    vcf = tmp_path / "input.vcf"
+    vcf.write_text("##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n")
+
+    monkeypatch.setattr(cli_module, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "variantcentrifuge",
+            "--vcf-file",
+            str(vcf),
+            "--gene-name",
+            "all",
+            "--filters",
+            "not_artefact",
+            "--output-dir",
+            str(tmp_path),
+            "--perform-association",
+            "--association-tests",
+            "logistic_burden",
+            "--variant-weights",
+            "score_column",
+            "--variant-weight-column",
+            "nephro_candidate_score",
+            "--variant-weight-params",
+            '{"score_min":0,"score_max":10,"floor":0.1}',
+        ],
+    )
+
+    exit_code = cli_module.main()
+
+    assert exit_code == 0
+    assert captured_configs[0]["variant_weights"] == "score_column"
+    assert captured_configs[0]["variant_weight_column"] == "nephro_candidate_score"
+    assert captured_configs[0]["variant_weight_params"] == {
+        "score_min": 0,
+        "score_max": 10,
+        "floor": 0.1,
+    }
+
+
+def test_variant_weight_params_cli_requires_json_object(monkeypatch, tmp_path):
+    from variantcentrifuge import cli as cli_module
+
+    vcf = tmp_path / "input.vcf"
+    vcf.write_text("##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n")
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "variantcentrifuge",
+            "--vcf-file",
+            str(vcf),
+            "--gene-name",
+            "all",
+            "--filters",
+            "not_artefact",
+            "--output-dir",
+            str(tmp_path),
+            "--perform-association",
+            "--association-tests",
+            "skat",
+            "--variant-weight-params",
+            '["score_min",0]',
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_module.main()
+
+    assert exc_info.value.code == 2
+
+
+def test_score_column_cli_requires_variant_weight_column(monkeypatch, tmp_path):
+    from variantcentrifuge import cli as cli_module
+
+    vcf = tmp_path / "input.vcf"
+    vcf.write_text("##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n")
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "variantcentrifuge",
+            "--vcf-file",
+            str(vcf),
+            "--gene-name",
+            "all",
+            "--filters",
+            "not_artefact",
+            "--output-dir",
+            str(tmp_path),
+            "--perform-association",
+            "--association-tests",
+            "skat",
+            "--variant-weights",
+            "score_column",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_module.main()
+
+    assert exc_info.value.code == 2
 
 
 class TestCriticalArgumentParsing:

--- a/tests/unit/test_association_engine.py
+++ b/tests/unit/test_association_engine.py
@@ -49,6 +49,16 @@ def _make_gene_data(
     }
 
 
+def test_engine_rejects_r_skat_with_score_column_before_dependency_check():
+    config = AssociationConfig(
+        skat_backend="r",
+        variant_weights="column:nephro_candidate_score",
+    )
+
+    with pytest.raises(ValueError, match="R SKAT backend supports only beta:a,b and uniform"):
+        AssociationEngine.from_names(["skat"], config)
+
+
 # ---------------------------------------------------------------------------
 # from_names() construction tests
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_association_fisher.py
+++ b/tests/unit/test_association_fisher.py
@@ -46,6 +46,27 @@ def _make_gene_data(
     }
 
 
+def test_fisher_ignores_score_column_variant_weights():
+    contingency_data = {
+        "proband_carrier_count": 4,
+        "control_carrier_count": 1,
+        "proband_count": 10,
+        "control_count": 10,
+        "n_qualifying_variants": 3,
+        "score_values": np.array([0.1, 0.5, 1.0]),
+    }
+    config = AssociationConfig(
+        variant_weights="column:nephro_candidate_score",
+        variant_weight_column="nephro_candidate_score",
+    )
+
+    result = FisherExactTest().run("GENE1", contingency_data, config)
+
+    assert result.test_name == "fisher"
+    assert result.p_value is not None
+    assert result.n_variants == 3
+
+
 def _run_fisher_direct(table: list[list[int]]) -> tuple[float, float]:
     """Run scipy.stats.fisher_exact directly — the bit-identical reference."""
     odds_ratio, pval = fisher_exact(table)

--- a/tests/unit/test_association_genotype_matrix.py
+++ b/tests/unit/test_association_genotype_matrix.py
@@ -478,6 +478,36 @@ class TestBuildGenotypeMatrixWarnings:
         assert isinstance(sample_mask, list)
         assert isinstance(warnings_list, list)
 
+    def test_build_genotype_matrix_can_return_keep_variants_mask(self) -> None:
+        gt_values = [
+            ["0/1", "0/1", "0/0", "0/0"],
+            ["./.", "./.", "0/0", "0/0"],
+            ["1/1", "0/1", "0/0", "0/0"],
+        ]
+        gene_df, vcf_samples, gt_cols = _make_gene_df(4, 3, gt_values)
+
+        geno, mafs, sample_mask, warnings_list, keep_mask = build_genotype_matrix(
+            gene_df,
+            vcf_samples,
+            gt_cols,
+            missing_site_threshold=0.25,
+            return_keep_mask=True,
+        )
+
+        assert geno.shape == (4, 2)
+        assert len(mafs) == 2
+        assert sample_mask == [True, True, True, True]
+        assert warnings_list == []
+        np.testing.assert_array_equal(keep_mask, np.array([True, False, True]))
+
+    def test_build_genotype_matrix_default_return_shape_stays_four_tuple(self) -> None:
+        gt_values = [["0/1", "0/0"]]
+        gene_df, vcf_samples, gt_cols = _make_gene_df(2, 1, gt_values)
+
+        result = build_genotype_matrix(gene_df, vcf_samples, gt_cols)
+
+        assert len(result) == 4
+
     def test_build_genotype_matrix_differential_missingness_warning(self) -> None:
         """Differential missingness >5% between cases/controls triggers warning."""
         # 10 samples: 5 cases, 5 controls

--- a/tests/unit/test_association_linear_burden.py
+++ b/tests/unit/test_association_linear_burden.py
@@ -81,6 +81,29 @@ def _make_contingency(
     }
 
 
+def test_linear_burden_raw_score_only_matches_manual_ols(
+    synthetic_quantitative_data,
+) -> None:
+    geno, phenotype, mafs = synthetic_quantitative_data
+    score_values = np.array([0.2, 0.4, 0.6, 0.8, 1.0], dtype=np.float64)
+    config = AssociationConfig(
+        variant_weights="column:nephro_candidate_score",
+        variant_weight_params={"combine_with_beta": False},
+    )
+
+    burden = geno @ score_values
+    design = sm.add_constant(burden.reshape(-1, 1))
+    fit = sm.OLS(phenotype, design).fit()
+
+    contingency = _make_contingency(geno, phenotype, mafs)
+    contingency["score_values"] = score_values
+    result = LinearBurdenTest().run("GENE1", contingency, config)
+
+    assert result.p_value is not None
+    assert result.p_value == pytest.approx(float(fit.pvalues[1]), rel=1e-6)
+    assert result.effect_size == pytest.approx(float(fit.params[1]), rel=1e-6)
+
+
 # ---------------------------------------------------------------------------
 # Manual statsmodels.OLS validation (BURDEN-02)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_association_logistic_burden.py
+++ b/tests/unit/test_association_logistic_burden.py
@@ -88,6 +88,30 @@ def _make_contingency(
     }
 
 
+def test_logistic_burden_passes_score_values_to_weight_resolver(
+    monkeypatch, synthetic_binary_data
+) -> None:
+    from variantcentrifuge.association import weights as weights_module
+
+    geno, phenotype, mafs = synthetic_binary_data
+    score_values = np.array([0.2, 0.4, 0.6, 0.8, 1.0], dtype=np.float64)
+    seen_kwargs: dict[str, object] = {}
+
+    def fake_get_weights(mafs_arg, weight_spec, **kwargs):
+        seen_kwargs.update(kwargs)
+        return np.ones(len(mafs_arg), dtype=np.float64)
+
+    monkeypatch.setattr(weights_module, "get_weights", fake_get_weights)
+    config = AssociationConfig(variant_weights="column:nephro_candidate_score")
+    contingency = _make_contingency(geno, phenotype, mafs)
+    contingency["score_values"] = score_values
+
+    result = LogisticBurdenTest().run("GENE1", contingency, config)
+
+    assert result.p_value is not None
+    assert seen_kwargs["score_values"] is score_values
+
+
 # ---------------------------------------------------------------------------
 # Manual statsmodels.Logit validation (BURDEN-01)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_association_args.py
+++ b/tests/unit/test_cli_association_args.py
@@ -200,3 +200,52 @@ def test_cli_skat_method_overrides_json():
     assoc_config = _build_assoc_config_from_context(ctx)
     # CLI wins: SKATO, not Burden
     assert assoc_config.skat_method == "SKATO"
+
+
+@pytest.mark.unit
+def test_variant_weight_column_from_cli_config():
+    ctx = _make_context(
+        {
+            "variant_weights": "score_column",
+            "variant_weight_column": "nephro_candidate_score",
+        }
+    )
+
+    assoc_config = _build_assoc_config_from_context(ctx)
+
+    assert assoc_config.variant_weights == "score_column"
+    assert assoc_config.variant_weight_column == "nephro_candidate_score"
+
+
+@pytest.mark.unit
+def test_variant_weight_column_json_fallback():
+    ctx = _make_context(
+        {
+            "association": {
+                "variant_weights": "score_column",
+                "variant_weight_column": "json_score",
+            }
+        }
+    )
+
+    assoc_config = _build_assoc_config_from_context(ctx)
+
+    assert assoc_config.variant_weights == "score_column"
+    assert assoc_config.variant_weight_column == "json_score"
+
+
+@pytest.mark.unit
+def test_cli_variant_weight_column_overrides_json():
+    ctx = _make_context(
+        {
+            "variant_weight_column": "cli_score",
+            "association": {
+                "variant_weights": "score_column",
+                "variant_weight_column": "json_score",
+            },
+        }
+    )
+
+    assoc_config = _build_assoc_config_from_context(ctx)
+
+    assert assoc_config.variant_weight_column == "cli_score"

--- a/tests/unit/test_coast_python.py
+++ b/tests/unit/test_coast_python.py
@@ -32,6 +32,32 @@ from variantcentrifuge.association.tests.allelic_series_python import PurePython
 # ---------------------------------------------------------------------------
 
 
+def test_python_coast_does_not_require_score_values_for_score_column_variant_weights():
+    from variantcentrifuge.association.base import AssociationConfig
+
+    config = AssociationConfig(
+        trait_type="binary",
+        variant_weights="column:nephro_candidate_score",
+        variant_weight_column="nephro_candidate_score",
+        coast_backend="python",
+    )
+    test = PurePythonCOASTTest()
+    contingency_data = {
+        "genotype_matrix": np.zeros((4, 0), dtype=np.float64),
+        "phenotype_vector": np.array([1.0, 1.0, 0.0, 0.0]),
+        "covariate_matrix": None,
+        "gene_df": pd.DataFrame({"GENE": pd.Series([], dtype=str)}),
+        "proband_count": 2,
+        "control_count": 2,
+        "n_qualifying_variants": 0,
+    }
+
+    result = test.run("GENE1", contingency_data, config)
+
+    assert result.test_name == "coast"
+    assert result.p_value is None
+
+
 def _make_gene_df(
     effects: list[str],
     impacts: list[str],

--- a/tests/unit/test_gl_quadrature.py
+++ b/tests/unit/test_gl_quadrature.py
@@ -72,6 +72,7 @@ class TestGLQuadratureAccuracy:
         sensible results comparable to the previous adaptive quad approach.
         """
         from variantcentrifuge.association.backends.python_backend import PythonSKATBackend
+        from variantcentrifuge.association.weights import beta_maf_weights
 
         rng = np.random.default_rng(42)
         n, p = 200, 20
@@ -92,11 +93,13 @@ class TestGLQuadratureAccuracy:
         backend.detect_environment()
 
         null_model = backend.fit_null_model(phenotype, None, "binary")
+        weights = beta_maf_weights(geno.mean(axis=0) / 2.0, a=1.0, b=25.0)
         result = backend.test_gene(
             gene="TEST_GENE",
             genotype_matrix=geno,
             null_model=null_model,
             method="SKATO",
+            weights=weights,
             weights_beta=(1.0, 25.0),
         )
 

--- a/tests/unit/test_json_config.py
+++ b/tests/unit/test_json_config.py
@@ -159,6 +159,14 @@ class TestValidateAssociationConfigDict:
         # We document this behavior with a passing test (not a bug)
         _validate_association_config_dict({"pca_components": True})
 
+    def test_variant_weight_column_must_be_string_when_present(self):
+        with pytest.raises(ValueError, match="'variant_weight_column' must be a string"):
+            _validate_association_config_dict({"variant_weight_column": ["ncs"]})
+
+    def test_variant_weight_params_must_be_dict_when_present(self):
+        with pytest.raises(ValueError, match="'variant_weight_params' must be an object"):
+            _validate_association_config_dict({"variant_weight_params": ["score_min", 0]})
+
 
 # ---------------------------------------------------------------------------
 # Tests: _build_assoc_config_from_context
@@ -410,3 +418,30 @@ class TestBuildAssocConfigFromContext:
         assert config.min_cases == 999
         assert config.max_case_control_ratio == 5.0
         assert config.min_case_carriers == 3
+
+    def test_variant_weight_column_validated_and_propagated(self):
+        ctx = _make_context(
+            {
+                "association": {
+                    "variant_weights": "score_column",
+                    "variant_weight_column": "nephro_candidate_score",
+                    "variant_weight_params": {
+                        "score_min": 0,
+                        "score_max": 10,
+                        "floor": 0.1,
+                        "combine_with_beta": True,
+                    },
+                }
+            }
+        )
+
+        config = _build_assoc_config_from_context(ctx)
+
+        assert config.variant_weights == "score_column"
+        assert config.variant_weight_column == "nephro_candidate_score"
+        assert config.variant_weight_params == {
+            "score_min": 0,
+            "score_max": 10,
+            "floor": 0.1,
+            "combine_with_beta": True,
+        }

--- a/tests/unit/test_score_column_association_integration.py
+++ b/tests/unit/test_score_column_association_integration.py
@@ -1,0 +1,78 @@
+"""Small association regression for score-column weights across burden and Python SKAT."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from unittest.mock import Mock
+
+import pandas as pd
+
+from variantcentrifuge.pipeline_core.context import PipelineContext
+from variantcentrifuge.pipeline_core.workspace import Workspace
+from variantcentrifuge.stages.analysis_stages import AssociationAnalysisStage
+
+
+def test_score_column_weights_run_logistic_burden_and_python_skat(tmp_path):
+    cases = [f"CASE{i}" for i in range(10)]
+    controls = [f"CTRL{i}" for i in range(10)]
+    samples = cases + controls
+
+    rows = []
+    for variant_idx, score in enumerate([2.0, 5.0, 9.0]):
+        row = {
+            "GENE": "GENE1",
+            "nephro_candidate_score": score,
+            "ANN_0__EFFECT": "missense_variant",
+        }
+        for sample_idx, _sample in enumerate(samples):
+            if variant_idx == 0:
+                gt = "0/1" if sample_idx < 8 else "0/0"
+            elif variant_idx == 1:
+                gt = "0/1" if 4 <= sample_idx < 14 else "0/0"
+            else:
+                gt = "1/1" if sample_idx in (0, 1, 10) else "0/0"
+            row[f"GEN_{sample_idx}__GT"] = gt
+        rows.append(row)
+
+    df = pd.DataFrame(rows)
+    workspace = Mock(spec=Workspace)
+    workspace.output_dir = tmp_path
+    workspace.intermediate_dir = tmp_path / "intermediate"
+    workspace.intermediate_dir.mkdir()
+    workspace.get_intermediate_path = lambda name: workspace.intermediate_dir / name
+    workspace.get_output_path = lambda name, ext=".tsv": workspace.output_dir / f"{name}{ext}"
+    workspace.base_name = "score_column_integration"
+
+    context = PipelineContext(
+        args=Namespace(),
+        config={
+            "perform_association": True,
+            "case_samples": cases,
+            "control_samples": controls,
+            "association_tests": ["logistic_burden", "skat"],
+            "skat_backend": "python",
+            "variant_weights": "score_column",
+            "variant_weight_column": "nephro_candidate_score",
+            "variant_weight_params": {
+                "score_min": 0,
+                "score_max": 10,
+                "floor": 0.1,
+                "combine_with_beta": True,
+            },
+            "output_dir": str(tmp_path),
+            "output_file_base": "score_column_integration",
+            "gzip_intermediates": False,
+        },
+        workspace=workspace,
+    )
+    context.current_dataframe = df
+    context.vcf_samples = samples
+
+    result_context = AssociationAnalysisStage()._process(context)
+
+    result_df = result_context.association_results
+    assert result_df is not None
+    assert not result_df.empty
+    assert "logistic_burden_pvalue" in result_df.columns
+    assert "skat_pvalue" in result_df.columns
+    assert "acat_o_pvalue" in result_df.columns

--- a/tests/unit/test_score_column_association_stage.py
+++ b/tests/unit/test_score_column_association_stage.py
@@ -1,0 +1,133 @@
+"""Stage-level tests for score-column variant weights."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from variantcentrifuge.pipeline_core.context import PipelineContext
+from variantcentrifuge.pipeline_core.workspace import Workspace
+from variantcentrifuge.stages.analysis_stages import AssociationAnalysisStage
+
+
+def _workspace(tmp_path):
+    workspace = Mock(spec=Workspace)
+    workspace.output_dir = tmp_path
+    workspace.intermediate_dir = tmp_path / "intermediate"
+    workspace.intermediate_dir.mkdir()
+    workspace.get_intermediate_path = lambda name: workspace.intermediate_dir / name
+    workspace.get_output_path = lambda name, ext=".tsv": workspace.output_dir / f"{name}{ext}"
+    workspace.base_name = "score_column_stage"
+    return workspace
+
+
+def _context(tmp_path, df, extra_config):
+    cases = [f"CASE{i}" for i in range(10)]
+    controls = [f"CTRL{i}" for i in range(10)]
+    config = {
+        "perform_association": True,
+        "case_samples": cases,
+        "control_samples": controls,
+        "association_tests": ["logistic_burden"],
+        "variant_weights": "score_column",
+        "variant_weight_column": "nephro_candidate_score",
+        "output_dir": str(tmp_path),
+        "output_file_base": "score_column_stage",
+        "gzip_intermediates": False,
+    }
+    config.update(extra_config)
+    ctx = PipelineContext(args=Namespace(), config=config, workspace=_workspace(tmp_path))
+    ctx.current_dataframe = df
+    ctx.vcf_samples = cases + controls
+    return ctx
+
+
+def _df_with_score():
+    sample_cols = {}
+    for i in range(20):
+        sample_cols[f"GEN_{i}__GT"] = ["0/1", "0/1", "0/0"]
+    return pd.DataFrame(
+        {
+            "GENE": ["GENE1", "GENE1", "GENE1"],
+            "nephro_candidate_score": [2.0, 5.0, 9.0],
+            "dbNSFP_CADD_phred": [10.0, 20.0, 30.0],
+            "dbNSFP_REVEL_score": [0.1, 0.2, 0.3],
+            "ANN_0__EFFECT": ["missense_variant", "stop_gained", "frameshift_variant"],
+            **sample_cols,
+        }
+    )
+
+
+def test_stage_fails_when_score_column_missing(tmp_path):
+    df = _df_with_score().drop(columns=["nephro_candidate_score"])
+    context = _context(tmp_path, df, {})
+
+    with pytest.raises(ValueError, match="variant weight column 'nephro_candidate_score'"):
+        AssociationAnalysisStage()._process(context)
+
+
+def test_stage_passes_score_column_to_lazy_builder(monkeypatch, tmp_path):
+    from variantcentrifuge.association.engine import AssociationEngine
+
+    captured_gene_data = []
+
+    def fake_run_all(self, gene_burden_data):
+        captured_gene_data.extend(gene_burden_data)
+        return pd.DataFrame(
+            {
+                "gene": ["GENE1"],
+                "n_cases": [10],
+                "n_controls": [10],
+                "n_variants": [3],
+                "logistic_burden_pvalue": [1.0],
+            }
+        )
+
+    monkeypatch.setattr(AssociationEngine, "run_all", fake_run_all)
+    context = _context(tmp_path, _df_with_score(), {})
+
+    AssociationAnalysisStage()._process(context)
+
+    builder = captured_gene_data[0]["_genotype_matrix_builder"]
+    assert builder.score_column == "nephro_candidate_score"
+    assert builder.cadd_column is None
+    assert builder.revel_column is None
+    assert builder.effect_column == "ANN_0__EFFECT"
+
+
+def test_stage_inline_column_spec_wins_over_variant_weight_column(monkeypatch, tmp_path):
+    from variantcentrifuge.association.engine import AssociationEngine
+
+    captured_gene_data = []
+
+    def fake_run_all(self, gene_burden_data):
+        captured_gene_data.extend(gene_burden_data)
+        return pd.DataFrame(
+            {
+                "gene": ["GENE1"],
+                "n_cases": [10],
+                "n_controls": [10],
+                "n_variants": [3],
+                "logistic_burden_pvalue": [1.0],
+            }
+        )
+
+    monkeypatch.setattr(AssociationEngine, "run_all", fake_run_all)
+    df = _df_with_score()
+    df["inline_score"] = [1.0, 2.0, 3.0]
+    context = _context(
+        tmp_path,
+        df,
+        {
+            "variant_weights": "column:inline_score",
+            "variant_weight_column": "nephro_candidate_score",
+        },
+    )
+
+    AssociationAnalysisStage()._process(context)
+
+    builder = captured_gene_data[0]["_genotype_matrix_builder"]
+    assert builder.score_column == "inline_score"

--- a/tests/unit/test_score_column_weights.py
+++ b/tests/unit/test_score_column_weights.py
@@ -113,6 +113,23 @@ def test_score_column_missing_default_is_floor_in_raw_mode(mafs):
     np.testing.assert_allclose(result, np.array([0.2, 0.1, 0.1]), rtol=1e-12)
 
 
+def test_score_column_missing_log_reflects_actual_fallback(mafs, caplog):
+    scores = np.array([0.2, np.nan, "."], dtype=object)
+    effects = np.array(["missense_variant", "stop_gained", "synonymous_variant"])
+
+    with caplog.at_level(logging.WARNING, logger="variantcentrifuge"):
+        score_column_weights(
+            mafs,
+            scores,
+            variant_effects=effects,
+            weight_params={"combine_with_beta": False, "floor": 0.1},
+        )
+
+    messages = [record.message for record in caplog.records if "score_column" in record.message]
+    assert any("floor=0.1" in message for message in messages)
+    assert not any("functional=1.0" in message for message in messages)
+
+
 def test_score_column_missing_neutral_invalid_in_raw_mode(mafs):
     scores = np.array([0.2, np.nan, 0.5], dtype=object)
 

--- a/tests/unit/test_score_column_weights.py
+++ b/tests/unit/test_score_column_weights.py
@@ -1,0 +1,174 @@
+"""Tests for arbitrary score-column variant weights."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pytest
+
+from variantcentrifuge.association.weights import (
+    beta_maf_weights,
+    get_weights,
+    resolve_score_weight_column,
+    score_column_weights,
+)
+
+
+@pytest.fixture
+def mafs() -> np.ndarray:
+    return np.array([0.01, 0.02, 0.05], dtype=np.float64)
+
+
+def test_resolve_score_weight_column_from_inline_column():
+    assert resolve_score_weight_column("column:nephro_candidate_score", None) == (
+        "nephro_candidate_score"
+    )
+
+
+def test_resolve_score_weight_column_inline_wins_over_separate(caplog):
+    caplog.set_level(logging.DEBUG, logger="variantcentrifuge")
+
+    result = resolve_score_weight_column("column:inline_score", "separate_score")
+
+    assert result == "inline_score"
+    assert "separate_score" in caplog.text
+
+
+def test_resolve_score_weight_column_from_friendly_form():
+    assert resolve_score_weight_column("score_column", "nephro_candidate_score") == (
+        "nephro_candidate_score"
+    )
+
+
+def test_resolve_score_weight_column_requires_column_for_friendly_form():
+    with pytest.raises(ValueError, match="score_column requires variant_weight_column"):
+        resolve_score_weight_column("score_column", None)
+
+
+def test_resolve_score_weight_column_rejects_empty_inline_column():
+    with pytest.raises(ValueError, match="column:<name> requires a non-empty column name"):
+        resolve_score_weight_column("column:", None)
+
+
+def test_score_column_default_combines_beta_with_unit_scale_scores(mafs):
+    scores = np.array([0.2, 0.5, 1.0], dtype=np.float64)
+
+    result = score_column_weights(mafs, scores)
+
+    expected = beta_maf_weights(mafs, a=1.0, b=25.0) * scores
+    np.testing.assert_allclose(result, expected, rtol=1e-12)
+
+
+def test_score_column_explicit_range_floor_and_beta_params(mafs):
+    scores = np.array([0.0, 5.0, 10.0], dtype=np.float64)
+
+    result = score_column_weights(
+        mafs,
+        scores,
+        weight_params={
+            "score_min": 0,
+            "score_max": 10,
+            "floor": 0.1,
+            "beta_a": 0.5,
+            "beta_b": 0.5,
+        },
+    )
+
+    functional = np.array([0.1, 0.5, 1.0], dtype=np.float64)
+    expected = beta_maf_weights(mafs, a=0.5, b=0.5) * functional
+    np.testing.assert_allclose(result, expected, rtol=1e-12)
+
+
+def test_score_column_raw_score_only_mode(mafs):
+    scores = np.array([0.2, 0.5, 2.0], dtype=np.float64)
+
+    result = score_column_weights(
+        mafs,
+        scores,
+        weight_params={"combine_with_beta": False, "ceiling": 1.0},
+    )
+
+    np.testing.assert_allclose(result, np.array([0.2, 0.5, 1.0]), rtol=1e-12)
+
+
+def test_score_column_missing_default_is_neutral_when_combined_with_beta(mafs):
+    scores = np.array([0.2, np.nan, "."], dtype=object)
+
+    result = score_column_weights(mafs, scores)
+
+    expected = beta_maf_weights(mafs) * np.array([0.2, 1.0, 1.0])
+    np.testing.assert_allclose(result, expected, rtol=1e-12)
+
+
+def test_score_column_missing_default_is_floor_in_raw_mode(mafs):
+    scores = np.array([0.2, np.nan, "."], dtype=object)
+
+    result = score_column_weights(
+        mafs,
+        scores,
+        weight_params={"combine_with_beta": False, "floor": 0.1},
+    )
+
+    np.testing.assert_allclose(result, np.array([0.2, 0.1, 0.1]), rtol=1e-12)
+
+
+def test_score_column_missing_neutral_invalid_in_raw_mode(mafs):
+    scores = np.array([0.2, np.nan, 0.5], dtype=object)
+
+    with pytest.raises(ValueError, match="missing='neutral'.*combine_with_beta=false"):
+        score_column_weights(
+            mafs,
+            scores,
+            weight_params={"combine_with_beta": False, "missing": "neutral"},
+        )
+
+
+@pytest.mark.parametrize(
+    "params, message",
+    [
+        ({"score_min": 10, "score_max": 0}, "score_min must be less than score_max"),
+        ({"floor": -0.1}, "floor must be >= 0"),
+        ({"ceiling": 0}, "ceiling must be > 0"),
+        ({"floor": 0.8, "ceiling": 0.5}, "floor must be <= ceiling"),
+        ({"beta_a": 0}, "beta_a must be > 0"),
+        ({"beta_b": -1}, "beta_b must be > 0"),
+        ({"missing": "mean"}, "missing must be one of"),
+    ],
+)
+def test_score_column_invalid_params_raise(mafs, params, message):
+    with pytest.raises(ValueError, match=message):
+        score_column_weights(mafs, np.array([0.1, 0.2, 0.3]), weight_params=params)
+
+
+def test_score_column_length_mismatch_raises(mafs):
+    with pytest.raises(ValueError, match="same length"):
+        score_column_weights(mafs, np.array([0.1, 0.2]))
+
+
+def test_get_weights_dispatches_inline_column(mafs):
+    scores = np.array([0.2, 0.5, 1.0], dtype=np.float64)
+
+    result = get_weights(mafs, "column:nephro_candidate_score", score_values=scores)
+
+    expected = score_column_weights(mafs, scores)
+    np.testing.assert_allclose(result, expected, rtol=1e-12)
+
+
+def test_get_weights_dispatches_score_column_alias(mafs):
+    scores = np.array([0.2, 0.5, 1.0], dtype=np.float64)
+
+    result = get_weights(mafs, "score_column", score_values=scores)
+
+    expected = score_column_weights(mafs, scores)
+    np.testing.assert_allclose(result, expected, rtol=1e-12)
+
+
+def test_get_weights_score_column_requires_score_values(mafs):
+    with pytest.raises(ValueError, match="requires score_values"):
+        get_weights(mafs, "score_column")
+
+
+def test_get_weights_column_empty_name_raises(mafs):
+    with pytest.raises(ValueError, match="column:<name> requires a non-empty column name"):
+        get_weights(mafs, "column:", score_values=np.array([0.1, 0.2, 0.3]))

--- a/tests/unit/test_score_column_weights.py
+++ b/tests/unit/test_score_column_weights.py
@@ -116,7 +116,7 @@ def test_score_column_missing_default_is_floor_in_raw_mode(mafs):
 def test_score_column_missing_neutral_invalid_in_raw_mode(mafs):
     scores = np.array([0.2, np.nan, 0.5], dtype=object)
 
-    with pytest.raises(ValueError, match="missing='neutral'.*combine_with_beta=false"):
+    with pytest.raises(ValueError, match=r"missing='neutral'.*combine_with_beta=false"):
         score_column_weights(
             mafs,
             scores,

--- a/tests/unit/test_skat_python_backend.py
+++ b/tests/unit/test_skat_python_backend.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+import scipy.stats
 
 from variantcentrifuge.association.backends.python_backend import _SKATO_RHO_GRID, PythonSKATBackend
 
@@ -61,6 +62,10 @@ def standard_geno():
     """50-sample, 5-variant genotype matrix with rank >= 2."""
     rng = np.random.default_rng(100)
     return rng.integers(0, 3, (50, 5)).astype(np.float64)
+
+
+def _unit_weights(genotype_matrix: np.ndarray) -> np.ndarray:
+    return np.ones(genotype_matrix.shape[1], dtype=np.float64)
 
 
 @pytest.fixture
@@ -225,11 +230,75 @@ class TestFitNullModel:
 class TestSKATTestGene:
     """Tests for PythonSKATBackend.test_gene() with method='SKAT'."""
 
+    def test_backend_skat_uses_explicit_weight_vector(self, monkeypatch):
+        from variantcentrifuge.association.backends.base import NullModelResult
+
+        backend = PythonSKATBackend()
+        geno = np.array(
+            [
+                [0.0, 1.0, 2.0],
+                [1.0, 0.0, 1.0],
+                [0.0, 1.0, 0.0],
+                [1.0, 1.0, 0.0],
+            ],
+            dtype=np.float64,
+        )
+        weights = np.array([2.0, 3.0, 5.0], dtype=np.float64)
+        null_model = NullModelResult(
+            model=None,
+            trait_type="quantitative",
+            n_samples=4,
+            adjustment=False,
+            extra={
+                "residuals": np.array([0.5, -0.5, 0.25, -0.25]),
+                "sigma2": 1.0,
+                "design_matrix": np.ones((4, 1), dtype=np.float64),
+            },
+        )
+        captured: dict[str, np.ndarray] = {}
+
+        def fake_eigenvalues(geno_weighted, null_model_arg):
+            captured["geno_weighted"] = geno_weighted.copy()
+            return np.array([1.0], dtype=np.float64)
+
+        monkeypatch.setattr(backend, "_compute_eigenvalues_filtered", fake_eigenvalues)
+        monkeypatch.setattr(
+            "variantcentrifuge.association.backends.python_backend.compute_pvalue",
+            lambda q_stat, lambdas: (0.5, "liu", True),
+        )
+
+        result = backend._test_skat("GENE1", geno, null_model, weights)
+
+        assert result["p_value"] == 0.5
+        np.testing.assert_allclose(captured["geno_weighted"], geno * weights[np.newaxis, :])
+
+    def test_backend_rejects_weight_length_mismatch(self):
+        from variantcentrifuge.association.backends.base import NullModelResult
+
+        backend = PythonSKATBackend()
+        geno = np.ones((4, 3), dtype=np.float64)
+        null_model = NullModelResult(
+            model=None,
+            trait_type="quantitative",
+            n_samples=4,
+            adjustment=False,
+            extra={"residuals": np.ones(4), "sigma2": 1.0},
+        )
+
+        with pytest.raises(ValueError, match="weights length"):
+            backend.test_gene(
+                gene="GENE1",
+                genotype_matrix=geno,
+                null_model=null_model,
+                method="SKAT",
+                weights=np.array([1.0, 2.0]),
+            )
+
     def test_skat_basic_returns_dict_with_required_keys(
         self, backend, binary_null_model, standard_geno
     ):
         """Basic SKAT call returns dict with p_value, p_method, n_variants."""
-        result = backend.test_gene("GENE1", standard_geno, binary_null_model, "SKAT", (1.0, 25.0))
+        result = backend.test_gene("GENE1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno))
         assert "p_value" in result
         assert "p_method" in result
         assert "p_converged" in result
@@ -237,7 +306,7 @@ class TestSKATTestGene:
 
     def test_skat_basic_p_value_float_or_none(self, backend, binary_null_model, standard_geno):
         """SKAT p_value is a float in [0, 1] or None."""
-        result = backend.test_gene("GENE1", standard_geno, binary_null_model, "SKAT", (1.0, 25.0))
+        result = backend.test_gene("GENE1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno))
         p = result["p_value"]
         if p is not None:
             assert isinstance(p, float)
@@ -245,12 +314,12 @@ class TestSKATTestGene:
 
     def test_skat_p_method_in_expected_set(self, backend, binary_null_model, standard_geno):
         """p_method must be 'davies', 'saddlepoint', 'liu', or None (skipped)."""
-        result = backend.test_gene("GENE1", standard_geno, binary_null_model, "SKAT", (1.0, 25.0))
+        result = backend.test_gene("GENE1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno))
         assert result["p_method"] in {"davies", "saddlepoint", "liu", None}
 
     def test_skat_p_converged_is_bool(self, backend, binary_null_model, standard_geno):
         """p_converged must be a bool."""
-        result = backend.test_gene("GENE1", standard_geno, binary_null_model, "SKAT", (1.0, 25.0))
+        result = backend.test_gene("GENE1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno))
         assert isinstance(result["p_converged"], bool)
 
     def test_skat_rank_deficient_returns_none_pvalue(self, backend, binary_null_model):
@@ -260,14 +329,14 @@ class TestSKATTestGene:
         # All columns identical => rank = 1 < 2
         base_col = rng.integers(0, 3, n).astype(np.float64)
         geno = np.column_stack([base_col] * 5)
-        result = backend.test_gene("GENE_RD", geno, binary_null_model, "SKAT", (1.0, 25.0))
+        result = backend.test_gene("GENE_RD", geno, binary_null_model, "SKAT", weights=_unit_weights(geno))
         assert result["p_value"] is None
         assert result["skip_reason"] == "rank_deficient"
 
     def test_skat_zero_variants_returns_none(self, backend, binary_null_model):
         """Zero-variant matrix (0 columns): p_value=None."""
         geno = np.zeros((50, 0))
-        result = backend.test_gene("GENE_EMPTY", geno, binary_null_model, "SKAT", (1.0, 25.0))
+        result = backend.test_gene("GENE_EMPTY", geno, binary_null_model, "SKAT", weights=_unit_weights(geno))
         assert result["p_value"] is None
         assert result["n_variants"] == 0
 
@@ -275,14 +344,14 @@ class TestSKATTestGene:
         """Single-variant matrix: rank < 2, should be skipped."""
         rng = np.random.default_rng(12)
         geno = rng.integers(0, 3, (50, 1)).astype(np.float64)
-        result = backend.test_gene("GENE_1V", geno, binary_null_model, "SKAT", (1.0, 25.0))
+        result = backend.test_gene("GENE_1V", geno, binary_null_model, "SKAT", weights=_unit_weights(geno))
         assert result["p_value"] is None
         assert result["skip_reason"] == "rank_deficient"
 
     def test_skat_all_zero_genotypes_graceful(self, backend, binary_null_model):
         """All-zero genotype matrix: handled gracefully (p_value=None or 1.0)."""
         geno = np.zeros((50, 5))
-        result = backend.test_gene("GENE_ZEROS", geno, binary_null_model, "SKAT", (1.0, 25.0))
+        result = backend.test_gene("GENE_ZEROS", geno, binary_null_model, "SKAT", weights=_unit_weights(geno))
         # Should not raise; p_value is None (rank_deficient) or 1.0
         assert result["p_value"] is None or result["p_value"] == pytest.approx(1.0), (
             f"Expected None or 1.0 for all-zero genotypes, got {result['p_value']}"
@@ -301,7 +370,7 @@ class TestSKATTestGene:
 
         patch_target = "variantcentrifuge.association.backends.python_backend.scipy.linalg.eigh"
         with patch(patch_target, spy_eigh):
-            backend.test_gene("GENE_EVR", standard_geno, binary_null_model, "SKAT", (1.0, 25.0))
+            backend.test_gene("GENE_EVR", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno))
 
         evr_calls = [c for c in calls if c.get("driver") == "evr"]
         assert len(evr_calls) >= 1, f"Expected eigh with driver='evr', got kwargs: {calls}"
@@ -309,14 +378,14 @@ class TestSKATTestGene:
     def test_skat_increments_genes_processed(self, backend, binary_null_model, standard_geno):
         """Each test_gene call increments the internal gene counter."""
         initial = backend._genes_processed
-        backend.test_gene("G1", standard_geno, binary_null_model, "SKAT", (1.0, 25.0))
-        backend.test_gene("G2", standard_geno, binary_null_model, "SKAT", (1.0, 25.0))
+        backend.test_gene("G1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno))
+        backend.test_gene("G2", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno))
         assert backend._genes_processed == initial + 2
 
     def test_skat_unknown_method_defaults_to_skat(self, backend, binary_null_model, standard_geno):
         """Unknown method falls back to SKAT without raising."""
         result = backend.test_gene(
-            "G_UNK", standard_geno, binary_null_model, "UNKNOWN", (1.0, 25.0)
+            "G_UNK", standard_geno, binary_null_model, "UNKNOWN", weights=_unit_weights(standard_geno)
         )
         # Should return a result (not crash)
         assert "p_value" in result
@@ -338,7 +407,7 @@ class TestSKATOTestGene:
         n = rank2_geno.shape[0]
         phenotype = rng.integers(0, 2, n).astype(np.float64)
         null = backend.fit_null_model(phenotype, None, "binary")
-        result = backend.test_gene("GENE_O", rank2_geno, null, "SKATO", (1.0, 25.0))
+        result = backend.test_gene("GENE_O", rank2_geno, null, "SKATO", weights=_unit_weights(rank2_geno))
         rho = result["rho"]
         if rho is not None:
             assert 0.0 <= rho <= 1.0, f"rho={rho} not in [0, 1]"
@@ -349,7 +418,7 @@ class TestSKATOTestGene:
         n = rank2_geno.shape[0]
         phenotype = rng.integers(0, 2, n).astype(np.float64)
         null = backend.fit_null_model(phenotype, None, "binary")
-        result = backend.test_gene("GENE_O", rank2_geno, null, "SKATO", (1.0, 25.0))
+        result = backend.test_gene("GENE_O", rank2_geno, null, "SKATO", weights=_unit_weights(rank2_geno))
         rho = result["rho"]
         if rho is not None:
             assert any(abs(rho - r) < 1e-10 for r in _SKATO_RHO_GRID), (
@@ -368,7 +437,7 @@ class TestSKATOTestGene:
         n = rank2_geno.shape[0]
         phenotype = rng.integers(0, 2, n).astype(np.float64)
         null = backend.fit_null_model(phenotype, None, "binary")
-        result = backend.test_gene("GENE_O", rank2_geno, null, "SKATO", (1.0, 25.0))
+        result = backend.test_gene("GENE_O", rank2_geno, null, "SKATO", weights=_unit_weights(rank2_geno))
         p = result["p_value"]
         if p is not None:
             assert 0.0 <= p <= 1.0, f"SKAT-O p={p:.6e} not in [0, 1]"
@@ -381,7 +450,7 @@ class TestSKATOTestGene:
         geno = np.column_stack([col] * 5)  # rank = 1
         phenotype = rng.integers(0, 2, n).astype(np.float64)
         null = backend.fit_null_model(phenotype, None, "binary")
-        result = backend.test_gene("GENE_O_RD", geno, null, "SKATO", (1.0, 25.0))
+        result = backend.test_gene("GENE_O_RD", geno, null, "SKATO", weights=_unit_weights(geno))
         assert result["p_value"] is None
         assert result["skip_reason"] == "rank_deficient"
 
@@ -395,10 +464,41 @@ class TestSKATOTestGene:
 class TestBurdenTestGene:
     """Tests for PythonSKATBackend.test_gene() with method='Burden'."""
 
+    def test_backend_burden_uses_explicit_weight_vector(self):
+        from variantcentrifuge.association.backends.base import NullModelResult
+
+        backend = PythonSKATBackend()
+        geno = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [1.0, 1.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        weights = np.array([1.0, 10.0, 100.0], dtype=np.float64)
+        residuals = np.array([1.0, -1.0, 0.5, -0.5], dtype=np.float64)
+        null_model = NullModelResult(
+            model=None,
+            trait_type="quantitative",
+            n_samples=4,
+            adjustment=False,
+            extra={"residuals": residuals, "sigma2": 1.0},
+        )
+
+        result = backend._test_burden("GENE1", geno, null_model, weights)
+
+        burden = geno @ weights
+        score = float(residuals @ burden)
+        variance = float(burden @ burden)
+        expected_p = float(2.0 * scipy.stats.norm.sf(abs(score / np.sqrt(variance))))
+        assert result["p_value"] == pytest.approx(expected_p)
+
     def test_burden_returns_p_value(self, backend, binary_null_model, standard_geno):
         """Burden test returns a valid p_value."""
         result = backend.test_gene(
-            "GENE_B", standard_geno, binary_null_model, "Burden", (1.0, 25.0)
+            "GENE_B", standard_geno, binary_null_model, "Burden", weights=_unit_weights(standard_geno)
         )
         p = result["p_value"]
         if p is not None:
@@ -407,7 +507,7 @@ class TestBurdenTestGene:
     def test_burden_p_method_is_analytical(self, backend, binary_null_model, standard_geno):
         """Burden p_method should be 'analytical'."""
         result = backend.test_gene(
-            "GENE_B", standard_geno, binary_null_model, "Burden", (1.0, 25.0)
+            "GENE_B", standard_geno, binary_null_model, "Burden", weights=_unit_weights(standard_geno)
         )
         if result["p_value"] is not None:
             assert result["p_method"] == "analytical", (
@@ -417,14 +517,14 @@ class TestBurdenTestGene:
     def test_burden_no_rho(self, backend, binary_null_model, standard_geno):
         """Burden test does not produce a rho value."""
         result = backend.test_gene(
-            "GENE_B", standard_geno, binary_null_model, "Burden", (1.0, 25.0)
+            "GENE_B", standard_geno, binary_null_model, "Burden", weights=_unit_weights(standard_geno)
         )
         assert result["rho"] is None
 
     def test_burden_all_zero_geno_handles_gracefully(self, backend, binary_null_model):
         """Burden on all-zero genotype handles gracefully (no crash)."""
         geno = np.zeros((50, 5))
-        result = backend.test_gene("GENE_BZ", geno, binary_null_model, "Burden", (1.0, 25.0))
+        result = backend.test_gene("GENE_BZ", geno, binary_null_model, "Burden", weights=_unit_weights(geno))
         # Should not raise; p_value may be None due to zero variance
         assert "p_value" in result
 

--- a/tests/unit/test_skat_python_backend.py
+++ b/tests/unit/test_skat_python_backend.py
@@ -298,7 +298,9 @@ class TestSKATTestGene:
         self, backend, binary_null_model, standard_geno
     ):
         """Basic SKAT call returns dict with p_value, p_method, n_variants."""
-        result = backend.test_gene("GENE1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno))
+        result = backend.test_gene(
+            "GENE1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno)
+        )
         assert "p_value" in result
         assert "p_method" in result
         assert "p_converged" in result
@@ -306,7 +308,9 @@ class TestSKATTestGene:
 
     def test_skat_basic_p_value_float_or_none(self, backend, binary_null_model, standard_geno):
         """SKAT p_value is a float in [0, 1] or None."""
-        result = backend.test_gene("GENE1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno))
+        result = backend.test_gene(
+            "GENE1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno)
+        )
         p = result["p_value"]
         if p is not None:
             assert isinstance(p, float)
@@ -314,12 +318,16 @@ class TestSKATTestGene:
 
     def test_skat_p_method_in_expected_set(self, backend, binary_null_model, standard_geno):
         """p_method must be 'davies', 'saddlepoint', 'liu', or None (skipped)."""
-        result = backend.test_gene("GENE1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno))
+        result = backend.test_gene(
+            "GENE1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno)
+        )
         assert result["p_method"] in {"davies", "saddlepoint", "liu", None}
 
     def test_skat_p_converged_is_bool(self, backend, binary_null_model, standard_geno):
         """p_converged must be a bool."""
-        result = backend.test_gene("GENE1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno))
+        result = backend.test_gene(
+            "GENE1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno)
+        )
         assert isinstance(result["p_converged"], bool)
 
     def test_skat_rank_deficient_returns_none_pvalue(self, backend, binary_null_model):
@@ -329,14 +337,18 @@ class TestSKATTestGene:
         # All columns identical => rank = 1 < 2
         base_col = rng.integers(0, 3, n).astype(np.float64)
         geno = np.column_stack([base_col] * 5)
-        result = backend.test_gene("GENE_RD", geno, binary_null_model, "SKAT", weights=_unit_weights(geno))
+        result = backend.test_gene(
+            "GENE_RD", geno, binary_null_model, "SKAT", weights=_unit_weights(geno)
+        )
         assert result["p_value"] is None
         assert result["skip_reason"] == "rank_deficient"
 
     def test_skat_zero_variants_returns_none(self, backend, binary_null_model):
         """Zero-variant matrix (0 columns): p_value=None."""
         geno = np.zeros((50, 0))
-        result = backend.test_gene("GENE_EMPTY", geno, binary_null_model, "SKAT", weights=_unit_weights(geno))
+        result = backend.test_gene(
+            "GENE_EMPTY", geno, binary_null_model, "SKAT", weights=_unit_weights(geno)
+        )
         assert result["p_value"] is None
         assert result["n_variants"] == 0
 
@@ -344,14 +356,18 @@ class TestSKATTestGene:
         """Single-variant matrix: rank < 2, should be skipped."""
         rng = np.random.default_rng(12)
         geno = rng.integers(0, 3, (50, 1)).astype(np.float64)
-        result = backend.test_gene("GENE_1V", geno, binary_null_model, "SKAT", weights=_unit_weights(geno))
+        result = backend.test_gene(
+            "GENE_1V", geno, binary_null_model, "SKAT", weights=_unit_weights(geno)
+        )
         assert result["p_value"] is None
         assert result["skip_reason"] == "rank_deficient"
 
     def test_skat_all_zero_genotypes_graceful(self, backend, binary_null_model):
         """All-zero genotype matrix: handled gracefully (p_value=None or 1.0)."""
         geno = np.zeros((50, 5))
-        result = backend.test_gene("GENE_ZEROS", geno, binary_null_model, "SKAT", weights=_unit_weights(geno))
+        result = backend.test_gene(
+            "GENE_ZEROS", geno, binary_null_model, "SKAT", weights=_unit_weights(geno)
+        )
         # Should not raise; p_value is None (rank_deficient) or 1.0
         assert result["p_value"] is None or result["p_value"] == pytest.approx(1.0), (
             f"Expected None or 1.0 for all-zero genotypes, got {result['p_value']}"
@@ -370,7 +386,13 @@ class TestSKATTestGene:
 
         patch_target = "variantcentrifuge.association.backends.python_backend.scipy.linalg.eigh"
         with patch(patch_target, spy_eigh):
-            backend.test_gene("GENE_EVR", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno))
+            backend.test_gene(
+                "GENE_EVR",
+                standard_geno,
+                binary_null_model,
+                "SKAT",
+                weights=_unit_weights(standard_geno),
+            )
 
         evr_calls = [c for c in calls if c.get("driver") == "evr"]
         assert len(evr_calls) >= 1, f"Expected eigh with driver='evr', got kwargs: {calls}"
@@ -378,14 +400,22 @@ class TestSKATTestGene:
     def test_skat_increments_genes_processed(self, backend, binary_null_model, standard_geno):
         """Each test_gene call increments the internal gene counter."""
         initial = backend._genes_processed
-        backend.test_gene("G1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno))
-        backend.test_gene("G2", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno))
+        backend.test_gene(
+            "G1", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno)
+        )
+        backend.test_gene(
+            "G2", standard_geno, binary_null_model, "SKAT", weights=_unit_weights(standard_geno)
+        )
         assert backend._genes_processed == initial + 2
 
     def test_skat_unknown_method_defaults_to_skat(self, backend, binary_null_model, standard_geno):
         """Unknown method falls back to SKAT without raising."""
         result = backend.test_gene(
-            "G_UNK", standard_geno, binary_null_model, "UNKNOWN", weights=_unit_weights(standard_geno)
+            "G_UNK",
+            standard_geno,
+            binary_null_model,
+            "UNKNOWN",
+            weights=_unit_weights(standard_geno),
         )
         # Should return a result (not crash)
         assert "p_value" in result
@@ -407,7 +437,9 @@ class TestSKATOTestGene:
         n = rank2_geno.shape[0]
         phenotype = rng.integers(0, 2, n).astype(np.float64)
         null = backend.fit_null_model(phenotype, None, "binary")
-        result = backend.test_gene("GENE_O", rank2_geno, null, "SKATO", weights=_unit_weights(rank2_geno))
+        result = backend.test_gene(
+            "GENE_O", rank2_geno, null, "SKATO", weights=_unit_weights(rank2_geno)
+        )
         rho = result["rho"]
         if rho is not None:
             assert 0.0 <= rho <= 1.0, f"rho={rho} not in [0, 1]"
@@ -418,7 +450,9 @@ class TestSKATOTestGene:
         n = rank2_geno.shape[0]
         phenotype = rng.integers(0, 2, n).astype(np.float64)
         null = backend.fit_null_model(phenotype, None, "binary")
-        result = backend.test_gene("GENE_O", rank2_geno, null, "SKATO", weights=_unit_weights(rank2_geno))
+        result = backend.test_gene(
+            "GENE_O", rank2_geno, null, "SKATO", weights=_unit_weights(rank2_geno)
+        )
         rho = result["rho"]
         if rho is not None:
             assert any(abs(rho - r) < 1e-10 for r in _SKATO_RHO_GRID), (
@@ -437,7 +471,9 @@ class TestSKATOTestGene:
         n = rank2_geno.shape[0]
         phenotype = rng.integers(0, 2, n).astype(np.float64)
         null = backend.fit_null_model(phenotype, None, "binary")
-        result = backend.test_gene("GENE_O", rank2_geno, null, "SKATO", weights=_unit_weights(rank2_geno))
+        result = backend.test_gene(
+            "GENE_O", rank2_geno, null, "SKATO", weights=_unit_weights(rank2_geno)
+        )
         p = result["p_value"]
         if p is not None:
             assert 0.0 <= p <= 1.0, f"SKAT-O p={p:.6e} not in [0, 1]"
@@ -498,7 +534,11 @@ class TestBurdenTestGene:
     def test_burden_returns_p_value(self, backend, binary_null_model, standard_geno):
         """Burden test returns a valid p_value."""
         result = backend.test_gene(
-            "GENE_B", standard_geno, binary_null_model, "Burden", weights=_unit_weights(standard_geno)
+            "GENE_B",
+            standard_geno,
+            binary_null_model,
+            "Burden",
+            weights=_unit_weights(standard_geno),
         )
         p = result["p_value"]
         if p is not None:
@@ -507,7 +547,11 @@ class TestBurdenTestGene:
     def test_burden_p_method_is_analytical(self, backend, binary_null_model, standard_geno):
         """Burden p_method should be 'analytical'."""
         result = backend.test_gene(
-            "GENE_B", standard_geno, binary_null_model, "Burden", weights=_unit_weights(standard_geno)
+            "GENE_B",
+            standard_geno,
+            binary_null_model,
+            "Burden",
+            weights=_unit_weights(standard_geno),
         )
         if result["p_value"] is not None:
             assert result["p_method"] == "analytical", (
@@ -517,14 +561,20 @@ class TestBurdenTestGene:
     def test_burden_no_rho(self, backend, binary_null_model, standard_geno):
         """Burden test does not produce a rho value."""
         result = backend.test_gene(
-            "GENE_B", standard_geno, binary_null_model, "Burden", weights=_unit_weights(standard_geno)
+            "GENE_B",
+            standard_geno,
+            binary_null_model,
+            "Burden",
+            weights=_unit_weights(standard_geno),
         )
         assert result["rho"] is None
 
     def test_burden_all_zero_geno_handles_gracefully(self, backend, binary_null_model):
         """Burden on all-zero genotype handles gracefully (no crash)."""
         geno = np.zeros((50, 5))
-        result = backend.test_gene("GENE_BZ", geno, binary_null_model, "Burden", weights=_unit_weights(geno))
+        result = backend.test_gene(
+            "GENE_BZ", geno, binary_null_model, "Burden", weights=_unit_weights(geno)
+        )
         # Should not raise; p_value may be None due to zero variance
         assert "p_value" in result
 

--- a/tests/unit/test_skat_python_comparison.py
+++ b/tests/unit/test_skat_python_comparison.py
@@ -37,6 +37,7 @@ from variantcentrifuge.association.weights import beta_maf_weights
 def _beta_weights(geno: np.ndarray) -> np.ndarray:
     return beta_maf_weights(geno.mean(axis=0) / 2.0, a=1.0, b=25.0)
 
+
 # ---------------------------------------------------------------------------
 # R reference constants
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_skat_python_comparison.py
+++ b/tests/unit/test_skat_python_comparison.py
@@ -31,6 +31,11 @@ from scipy.stats import chi2
 from variantcentrifuge.association.backends.davies import compute_pvalue
 from variantcentrifuge.association.backends.python_backend import PythonSKATBackend
 from variantcentrifuge.association.tests.skat_python import PurePythonSKATTest
+from variantcentrifuge.association.weights import beta_maf_weights
+
+
+def _beta_weights(geno: np.ndarray) -> np.ndarray:
+    return beta_maf_weights(geno.mean(axis=0) / 2.0, a=1.0, b=25.0)
 
 # ---------------------------------------------------------------------------
 # R reference constants
@@ -182,7 +187,7 @@ class TestSelfConsistency:
         p_values = []
         for _ in range(50):
             geno = rng.choice([0, 1, 2], size=(n, 5), p=[0.6, 0.3, 0.1]).astype(np.float64)
-            result = backend.test_gene("GENE", geno, null, "Burden", (1.0, 25.0))
+            result = backend.test_gene("GENE", geno, null, "Burden", weights=_beta_weights(geno))
             if result["p_value"] is not None:
                 p_values.append(result["p_value"])
 
@@ -204,7 +209,7 @@ class TestSelfConsistency:
         geno[50:, :] = rng.choice([0, 1], size=(50, 8), p=[0.8, 0.2]).astype(np.float64)
 
         null = backend.fit_null_model(phenotype, None, "binary")
-        result = backend.test_gene("SIGNAL_GENE", geno, null, "Burden", (1.0, 25.0))
+        result = backend.test_gene("SIGNAL_GENE", geno, null, "Burden", weights=_beta_weights(geno))
 
         p = result["p_value"]
         assert p is not None, "Expected a p-value for strong signal gene"
@@ -224,9 +229,9 @@ class TestSelfConsistency:
         geno = rng.choice([0, 1, 2], size=(n, 8), p=[0.6, 0.3, 0.1]).astype(np.float64)
         null = backend.fit_null_model(phenotype, None, "binary")
 
-        r_skat = backend.test_gene("G", geno, null, "SKAT", (1.0, 25.0))
-        r_burden = backend.test_gene("G", geno, null, "Burden", (1.0, 25.0))
-        r_skato = backend.test_gene("G", geno, null, "SKATO", (1.0, 25.0))
+        r_skat = backend.test_gene("G", geno, null, "SKAT", weights=_beta_weights(geno))
+        r_burden = backend.test_gene("G", geno, null, "Burden", weights=_beta_weights(geno))
+        r_skato = backend.test_gene("G", geno, null, "SKATO", weights=_beta_weights(geno))
 
         p_skat = r_skat["p_value"]
         p_burden = r_burden["p_value"]
@@ -249,8 +254,8 @@ class TestSelfConsistency:
 
         null = backend.fit_null_model(phenotype, None, "binary")
 
-        r1 = backend.test_gene("G", geno, null, "Burden", (1.0, 25.0))
-        r2 = backend.test_gene("G", geno, null, "Burden", (1.0, 25.0))
+        r1 = backend.test_gene("G", geno, null, "Burden", weights=_beta_weights(geno))
+        r2 = backend.test_gene("G", geno, null, "Burden", weights=_beta_weights(geno))
 
         assert r1["p_value"] == r2["p_value"], (
             f"Non-deterministic: {r1['p_value']} != {r2['p_value']}"
@@ -376,7 +381,7 @@ class TestGoldenValues:
             _GENE_A_SEED, _GENE_A_N, _GENE_A_K, _GENE_A_TRAIT, _GENE_A_EFFECT
         )
         null = backend.fit_null_model(phenotype, None, _GENE_A_TRAIT)
-        result = backend.test_gene("GENE_A", geno, null, "Burden", (1.0, 25.0))
+        result = backend.test_gene("GENE_A", geno, null, "Burden", weights=_beta_weights(geno))
         p = result["p_value"]
         assert p is not None, "Gene A should have a valid p-value"
         # Golden value: 0.8166240139405816 (captured 2026-02-21)
@@ -390,7 +395,7 @@ class TestGoldenValues:
             _GENE_A_SEED, _GENE_A_N, _GENE_A_K, _GENE_A_TRAIT, _GENE_A_EFFECT
         )
         null = backend.fit_null_model(phenotype, None, _GENE_A_TRAIT)
-        result = backend.test_gene("GENE_A", geno, null, "SKAT", (1.0, 25.0))
+        result = backend.test_gene("GENE_A", geno, null, "SKAT", weights=_beta_weights(geno))
         p = result["p_value"]
         # Under null, p should be large (no signal => Q small relative to null dist)
         # Value: 0.519 (projection-adjusted eigenvalues / 2, R-compat Davies params)
@@ -405,7 +410,7 @@ class TestGoldenValues:
             _GENE_C_SEED, _GENE_C_N, _GENE_C_K, _GENE_C_TRAIT, _GENE_C_EFFECT
         )
         null = backend.fit_null_model(phenotype, None, _GENE_C_TRAIT)
-        result = backend.test_gene("GENE_C", geno, null, "Burden", (1.0, 25.0))
+        result = backend.test_gene("GENE_C", geno, null, "Burden", weights=_beta_weights(geno))
         p = result["p_value"]
         if p is not None:
             assert 0.0 < p <= 1.0, f"Gene C p-value out of range: {p:.6e}"
@@ -460,7 +465,7 @@ class TestRReferenceValidation:
         """
         phenotype, geno = _make_gene_data(seed, n, k, trait_type, effect)
         null = backend.fit_null_model(phenotype, None, trait_type)
-        result = backend.test_gene("REF_GENE", geno, null, "Burden", (1.0, 25.0))
+        result = backend.test_gene("REF_GENE", geno, null, "Burden", weights=_beta_weights(geno))
 
         p = result["p_value"]
         assert p is not None, f"Expected valid p for seed={seed}"
@@ -491,7 +496,7 @@ class TestRReferenceValidation:
         )
 
         null = backend.fit_null_model(phenotype, None, "binary")
-        result = backend.test_gene("GENE_B", geno, null, "Burden", (1.0, 25.0))
+        result = backend.test_gene("GENE_B", geno, null, "Burden", weights=_beta_weights(geno))
 
         p = result["p_value"]
         assert p is not None, "Expected valid p for strong signal gene"
@@ -508,7 +513,7 @@ class TestRReferenceValidation:
         """SKAT test returns valid p-value for reference genes."""
         phenotype, geno = _make_gene_data(seed, n, k, trait_type, 0.0)
         null = backend.fit_null_model(phenotype, None, trait_type)
-        result = backend.test_gene("REF_GENE", geno, null, "SKAT", (1.0, 25.0))
+        result = backend.test_gene("REF_GENE", geno, null, "SKAT", weights=_beta_weights(geno))
         p = result["p_value"]
         if p is not None:
             assert 0.0 <= p <= 1.0, f"p={p:.6e} out of [0, 1]"

--- a/tests/unit/test_skat_python_weights.py
+++ b/tests/unit/test_skat_python_weights.py
@@ -1,0 +1,164 @@
+"""Tests for PurePythonSKATTest variant weight resolution."""
+
+from __future__ import annotations
+
+from types import MethodType
+
+import numpy as np
+import pytest
+
+from variantcentrifuge.association.base import AssociationConfig
+from variantcentrifuge.association.tests.skat_python import PurePythonSKATTest
+from variantcentrifuge.association.weights import beta_maf_weights, get_weights
+
+
+def _contingency(geno, phenotype, **extra):
+    data = {
+        "genotype_matrix": geno,
+        "phenotype_vector": phenotype,
+        "covariate_matrix": None,
+        "proband_count": int(phenotype.sum()),
+        "control_count": int((phenotype == 0).sum()),
+        "n_qualifying_variants": geno.shape[1],
+    }
+    data.update(extra)
+    return data
+
+
+def _make_test_with_capture(monkeypatch):
+    test = PurePythonSKATTest()
+    test.check_dependencies()
+    captured: dict[str, np.ndarray] = {}
+
+    def fake_test_gene(self, gene, genotype_matrix, null_model, method, weights=None, weights_beta=None):
+        captured["backend_weights"] = np.asarray(weights, dtype=np.float64).copy()
+        return {
+            "p_value": 0.5,
+            "rho": None,
+            "n_variants": genotype_matrix.shape[1],
+            "n_marker_test": genotype_matrix.shape[1],
+            "warnings": [],
+            "p_method": "test",
+            "p_converged": True,
+            "skip_reason": None,
+        }
+
+    test._backend.test_gene = MethodType(fake_test_gene, test._backend)
+
+    def fake_acat_v(**kwargs):
+        captured["acat_v_weights"] = np.asarray(kwargs["weights"], dtype=np.float64).copy()
+        return 0.75
+
+    monkeypatch.setattr(
+        "variantcentrifuge.association.tests.skat_python.compute_acat_v",
+        fake_acat_v,
+    )
+    return test, captured
+
+
+def test_python_skat_resolves_score_column_weights_for_backend_and_acat_v(monkeypatch):
+    geno = np.array(
+        [
+            [0.0, 1.0, 2.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    phenotype = np.array([1, 1, 1, 0, 0, 0], dtype=float)
+    score_values = np.array([0.2, 0.5, 1.0], dtype=np.float64)
+    config = AssociationConfig(
+        trait_type="binary",
+        variant_weights="column:nephro_candidate_score",
+        variant_weight_params={"combine_with_beta": False},
+    )
+    test, captured = _make_test_with_capture(monkeypatch)
+
+    result = test.run(
+        "GENE1",
+        _contingency(geno, phenotype, score_values=score_values),
+        config,
+    )
+
+    expected = get_weights(
+        geno.mean(axis=0) / 2.0,
+        "column:nephro_candidate_score",
+        score_values=score_values,
+        weight_params={"combine_with_beta": False},
+    )
+    assert result.extra["acat_v_p"] == 0.75
+    np.testing.assert_allclose(captured["backend_weights"], expected)
+    np.testing.assert_allclose(captured["acat_v_weights"], expected)
+
+
+@pytest.mark.parametrize(
+    "variant_weights, extra_key, extra_values",
+    [
+        ("cadd", "cadd_scores", np.array([30.0, 20.0, 10.0], dtype=np.float64)),
+        ("revel", "revel_scores", np.array([0.9, 0.5, 0.1], dtype=np.float64)),
+        ("combined", "cadd_scores", np.array([30.0, 20.0, 10.0], dtype=np.float64)),
+    ],
+)
+def test_python_skat_honors_functional_weight_schemes(
+    monkeypatch,
+    variant_weights,
+    extra_key,
+    extra_values,
+):
+    geno = np.array(
+        [
+            [0.0, 1.0, 2.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    phenotype = np.array([1, 1, 1, 0, 0, 0], dtype=float)
+    config = AssociationConfig(trait_type="binary", variant_weights=variant_weights)
+    test, captured = _make_test_with_capture(monkeypatch)
+    contingency = _contingency(geno, phenotype, **{extra_key: extra_values})
+
+    test.run("GENE1", contingency, config)
+
+    expected = get_weights(
+        geno.mean(axis=0) / 2.0,
+        variant_weights,
+        cadd_scores=contingency.get("cadd_scores"),
+        revel_scores=contingency.get("revel_scores"),
+    )
+    np.testing.assert_allclose(captured["backend_weights"], expected)
+
+
+def test_python_skat_beta_uses_post_imputation_genotype_maf(monkeypatch):
+    geno = np.array(
+        [
+            [0.0, 1.0, 2.0],
+            [0.0, 1.0, 2.0],
+            [1.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 0.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    phenotype = np.array([1, 1, 1, 0, 0, 0], dtype=float)
+    pre_imputation_mafs = np.array([0.01, 0.01, 0.01], dtype=np.float64)
+    config = AssociationConfig(trait_type="binary", variant_weights="beta:1,25")
+    test, captured = _make_test_with_capture(monkeypatch)
+
+    test.run(
+        "GENE1",
+        _contingency(geno, phenotype, variant_mafs=pre_imputation_mafs),
+        config,
+    )
+
+    expected = beta_maf_weights(geno.mean(axis=0) / 2.0, a=1.0, b=25.0)
+    not_expected = beta_maf_weights(pre_imputation_mafs, a=1.0, b=25.0)
+    np.testing.assert_allclose(captured["backend_weights"], expected)
+    assert not np.allclose(captured["backend_weights"], not_expected)

--- a/tests/unit/test_skat_python_weights.py
+++ b/tests/unit/test_skat_python_weights.py
@@ -30,7 +30,9 @@ def _make_test_with_capture(monkeypatch):
     test.check_dependencies()
     captured: dict[str, np.ndarray] = {}
 
-    def fake_test_gene(self, gene, genotype_matrix, null_model, method, weights=None, weights_beta=None):
+    def fake_test_gene(
+        self, gene, genotype_matrix, null_model, method, weights=None, weights_beta=None
+    ):
         captured["backend_weights"] = np.asarray(weights, dtype=np.float64).copy()
         return {
             "p_value": 0.5,

--- a/tests/unit/test_skat_r_test.py
+++ b/tests/unit/test_skat_r_test.py
@@ -508,3 +508,23 @@ class TestProgressTracking:
 
         result = test.run("GENE1", _make_geno_data("GENE1"), config)
         assert result.test_name == "skat"
+
+
+def test_r_skat_run_rejects_functional_weights_without_r_backend():
+    from variantcentrifuge.association.base import AssociationConfig
+    from variantcentrifuge.association.tests.skat_r import RSKATTest
+
+    config = AssociationConfig(skat_backend="r", variant_weights="cadd")
+    contingency_data = {
+        "genotype_matrix": np.ones((4, 2), dtype=np.float64),
+        "phenotype_vector": np.array([1.0, 1.0, 0.0, 0.0]),
+        "covariate_matrix": None,
+        "proband_count": 2,
+        "control_count": 2,
+        "n_qualifying_variants": 2,
+    }
+
+    test = RSKATTest()
+
+    with pytest.raises(ValueError, match="Use --skat-backend python"):
+        test.run("GENE1", contingency_data, config)

--- a/tests/unit/test_streaming_matrix.py
+++ b/tests/unit/test_streaming_matrix.py
@@ -228,3 +228,105 @@ class TestEngineBuilderConsumption:
         result_df = engine.run_all(gene_data)
         assert result_df is not None
         assert len(result_df) >= 0  # may be empty if no testable variants
+
+
+def test_builder_aligns_score_values_with_real_keep_mask():
+    from variantcentrifuge.stages.analysis_stages import _GenotypeMatrixBuilder
+
+    df = pd.DataFrame(
+        {
+            "GENE": ["A", "A", "A"],
+            "nephro_candidate_score": [1.0, 99.0, 7.0],
+            "GEN_0__GT": ["0/1", "./.", "1/1"],
+            "GEN_1__GT": ["0/1", "./.", "0/1"],
+            "GEN_2__GT": ["0/1", "0/0", "0/1"],
+            "GEN_3__GT": ["0/1", "0/0", "0/0"],
+        }
+    )
+    builder = _GenotypeMatrixBuilder(
+        gene_df=df,
+        vcf_samples=["S1", "S2", "S3", "S4"],
+        gt_columns=["GEN_0__GT", "GEN_1__GT", "GEN_2__GT", "GEN_3__GT"],
+        is_binary=True,
+        missing_site_threshold=0.25,
+        missing_sample_threshold=0.80,
+        phenotype_vector=np.array([1, 1, 0, 0]),
+        covariate_matrix=None,
+        score_column="nephro_candidate_score",
+    )
+
+    result = builder()
+
+    assert result["genotype_matrix"].shape[1] == 2
+    np.testing.assert_array_equal(result["score_values"], np.array([1.0, 7.0], dtype=object))
+    assert result["variant_weight_column"] == "nephro_candidate_score"
+
+
+def test_builder_aligns_functional_annotation_arrays_with_real_keep_mask():
+    from variantcentrifuge.stages.analysis_stages import _GenotypeMatrixBuilder
+
+    df = pd.DataFrame(
+        {
+            "GENE": ["A", "A", "A"],
+            "dbNSFP_CADD_phred": [30.0, 99.0, 12.0],
+            "dbNSFP_REVEL_score": [0.9, 0.1, 0.4],
+            "ANN_0__EFFECT": ["missense_variant", "stop_gained", "frameshift_variant"],
+            "GEN_0__GT": ["0/1", "./.", "1/1"],
+            "GEN_1__GT": ["0/1", "./.", "0/1"],
+            "GEN_2__GT": ["0/1", "0/0", "0/1"],
+            "GEN_3__GT": ["0/1", "0/0", "0/0"],
+        }
+    )
+    builder = _GenotypeMatrixBuilder(
+        gene_df=df,
+        vcf_samples=["S1", "S2", "S3", "S4"],
+        gt_columns=["GEN_0__GT", "GEN_1__GT", "GEN_2__GT", "GEN_3__GT"],
+        is_binary=True,
+        missing_site_threshold=0.25,
+        missing_sample_threshold=0.80,
+        phenotype_vector=np.array([1, 1, 0, 0]),
+        covariate_matrix=None,
+        cadd_column="dbNSFP_CADD_phred",
+        revel_column="dbNSFP_REVEL_score",
+        effect_column="ANN_0__EFFECT",
+    )
+
+    result = builder()
+
+    np.testing.assert_array_equal(result["cadd_scores"], np.array([30.0, 12.0], dtype=object))
+    np.testing.assert_array_equal(result["revel_scores"], np.array([0.9, 0.4], dtype=object))
+    np.testing.assert_array_equal(
+        result["variant_effects"],
+        np.array(["missense_variant", "frameshift_variant"], dtype=object),
+    )
+
+
+def test_builder_uses_parser_keep_mask_for_malformed_genotypes():
+    from variantcentrifuge.stages.analysis_stages import _GenotypeMatrixBuilder
+
+    df = pd.DataFrame(
+        {
+            "GENE": ["A", "A", "A"],
+            "nephro_candidate_score": [1.0, 99.0, 7.0],
+            "GEN_0__GT": ["0/1", "0/x", "1/1"],
+            "GEN_1__GT": ["0/1", "0/x", "0/1"],
+            "GEN_2__GT": ["0/1", "0/x", "0/1"],
+            "GEN_3__GT": ["0/1", "0/x", "0/0"],
+        }
+    )
+    builder = _GenotypeMatrixBuilder(
+        gene_df=df,
+        vcf_samples=["S1", "S2", "S3", "S4"],
+        gt_columns=["GEN_0__GT", "GEN_1__GT", "GEN_2__GT", "GEN_3__GT"],
+        is_binary=True,
+        missing_site_threshold=0.25,
+        missing_sample_threshold=0.80,
+        phenotype_vector=np.array([1, 1, 0, 0]),
+        covariate_matrix=None,
+        score_column="nephro_candidate_score",
+    )
+
+    result = builder()
+
+    assert result["genotype_matrix"].shape[1] == 2
+    np.testing.assert_array_equal(result["score_values"], np.array([1.0, 7.0], dtype=object))

--- a/tests/unit/test_streaming_matrix.py
+++ b/tests/unit/test_streaming_matrix.py
@@ -330,3 +330,75 @@ def test_builder_uses_parser_keep_mask_for_malformed_genotypes():
 
     assert result["genotype_matrix"].shape[1] == 2
     np.testing.assert_array_equal(result["score_values"], np.array([1.0, 7.0], dtype=object))
+
+
+def test_engine_passes_builder_score_values_to_tests_and_discards_payload():
+    from variantcentrifuge.association.base import AssociationConfig, AssociationTest, TestResult
+    from variantcentrifuge.association.engine import AssociationEngine
+    from variantcentrifuge.stages.analysis_stages import _GenotypeMatrixBuilder
+
+    seen: dict[str, object] = {}
+
+    class RecordingTest(AssociationTest):
+        parallel_safe = True
+
+        @property
+        def name(self) -> str:
+            return "recording"
+
+        def run(self, gene, contingency_data, config):
+            seen["score_values"] = contingency_data.get("score_values")
+            seen["variant_weight_column"] = contingency_data.get("variant_weight_column")
+            return TestResult(
+                gene=gene,
+                test_name=self.name,
+                p_value=1.0,
+                corrected_p_value=None,
+                effect_size=None,
+                ci_lower=None,
+                ci_upper=None,
+                se=None,
+                n_cases=2,
+                n_controls=2,
+                n_variants=2,
+            )
+
+    df = pd.DataFrame(
+        {
+            "GENE": ["A", "A"],
+            "nephro_candidate_score": [2.0, 8.0],
+            "GEN_0__GT": ["0/1", "1/1"],
+            "GEN_1__GT": ["0/1", "0/1"],
+            "GEN_2__GT": ["0/0", "0/1"],
+            "GEN_3__GT": ["0/0", "0/0"],
+        }
+    )
+    builder = _GenotypeMatrixBuilder(
+        gene_df=df,
+        vcf_samples=["S1", "S2", "S3", "S4"],
+        gt_columns=["GEN_0__GT", "GEN_1__GT", "GEN_2__GT", "GEN_3__GT"],
+        is_binary=True,
+        missing_site_threshold=0.25,
+        missing_sample_threshold=0.80,
+        phenotype_vector=np.array([1, 1, 0, 0]),
+        covariate_matrix=None,
+        score_column="nephro_candidate_score",
+    )
+    gene_data = [
+        {
+            "GENE": "A",
+            "proband_count": 2,
+            "control_count": 2,
+            "n_qualifying_variants": 2,
+            "_genotype_matrix_builder": builder,
+        }
+    ]
+
+    engine = AssociationEngine([RecordingTest()], AssociationConfig())
+    result_df = engine.run_all(gene_data)
+
+    assert result_df is not None
+    np.testing.assert_array_equal(seen["score_values"], np.array([2.0, 8.0], dtype=object))
+    assert seen["variant_weight_column"] == "nephro_candidate_score"
+    assert "score_values" not in gene_data[0]
+    assert "variant_weight_column" not in gene_data[0]

--- a/variantcentrifuge/association/backends/base.py
+++ b/variantcentrifuge/association/backends/base.py
@@ -155,7 +155,8 @@ class SKATBackend(ABC):
         genotype_matrix: np.ndarray,
         null_model: NullModelResult,
         method: str,
-        weights_beta: tuple[float, float],
+        weights: np.ndarray | None = None,
+        weights_beta: tuple[float, float] | None = None,
     ) -> dict[str, Any]:
         """
         Run the SKAT test for a single gene.
@@ -171,9 +172,11 @@ class SKATBackend(ABC):
             Fitted null model from fit_null_model().
         method : str
             SKAT variant: "SKAT" (default), "Burden", or "SKATO".
-        weights_beta : tuple of (float, float)
-            Beta distribution parameters (a1, a2) for variant weights.
-            SKAT convention: (1, 25).
+        weights : np.ndarray or None
+            Concrete per-variant weights aligned to genotype_matrix columns. Python SKAT
+            requires this path.
+        weights_beta : tuple of (float, float) or None
+            Legacy Beta parameters used by the deprecated R backend.
 
         Returns
         -------

--- a/variantcentrifuge/association/backends/python_backend.py
+++ b/variantcentrifuge/association/backends/python_backend.py
@@ -66,6 +66,7 @@ from variantcentrifuge.association.backends.davies import (
     compute_pvalue,
     davies_pvalue,
 )
+
 logger = logging.getLogger("variantcentrifuge")
 
 # Fixed SKAT-O rho search grid (matches R SKAT package default)

--- a/variantcentrifuge/association/backends/python_backend.py
+++ b/variantcentrifuge/association/backends/python_backend.py
@@ -66,8 +66,6 @@ from variantcentrifuge.association.backends.davies import (
     compute_pvalue,
     davies_pvalue,
 )
-from variantcentrifuge.association.weights import beta_maf_weights
-
 logger = logging.getLogger("variantcentrifuge")
 
 # Fixed SKAT-O rho search grid (matches R SKAT package default)
@@ -658,7 +656,8 @@ class PythonSKATBackend(SKATBackend):
         genotype_matrix: np.ndarray,
         null_model: NullModelResult,
         method: str,
-        weights_beta: tuple[float, float],
+        weights: np.ndarray | None = None,
+        weights_beta: tuple[float, float] | None = None,
     ) -> dict[str, Any]:
         """
         Run the SKAT test for a single gene.
@@ -675,8 +674,10 @@ class PythonSKATBackend(SKATBackend):
             Fitted null model from fit_null_model().
         method : str
             "SKAT", "Burden", or "SKATO".
-        weights_beta : tuple of (float, float)
-            Beta distribution parameters (a1, a2). SKAT default: (1.0, 25.0).
+        weights : np.ndarray or None
+            Concrete per-variant weights aligned to genotype_matrix columns.
+        weights_beta : tuple of (float, float) or None
+            Deprecated legacy parameter accepted only for API compatibility.
 
         Returns
         -------
@@ -685,25 +686,42 @@ class PythonSKATBackend(SKATBackend):
         """
         self._genes_processed += 1
         n_variants = genotype_matrix.shape[1]
+        weights_arr = self._validate_variant_weights(genotype_matrix, weights)
 
         method_upper = method.upper()
         # Map R SKAT method names to our internal names
         # "optimal.adj" and "optimal" are R's names for SKAT-O
         if method_upper == "SKAT":
-            result = self._test_skat(gene, genotype_matrix, null_model, weights_beta)
+            result = self._test_skat(gene, genotype_matrix, null_model, weights_arr)
         elif method_upper == "BURDEN":
-            result = self._test_burden(gene, genotype_matrix, null_model, weights_beta)
+            result = self._test_burden(gene, genotype_matrix, null_model, weights_arr)
         elif method_upper in ("SKATO", "OPTIMAL.ADJ", "OPTIMAL"):
-            result = self._test_skato(gene, genotype_matrix, null_model, weights_beta)
+            result = self._test_skato(gene, genotype_matrix, null_model, weights_arr)
         else:
             logger.warning(f"Unknown SKAT method '{method}' for gene {gene}; using SKAT")
-            result = self._test_skat(gene, genotype_matrix, null_model, weights_beta)
+            result = self._test_skat(gene, genotype_matrix, null_model, weights_arr)
 
         logger.debug(
             f"Gene {gene}: method={method}, p={result.get('p_value')}, "
             f"n_variants={n_variants}, p_method={result.get('p_method')}"
         )
         return result
+
+    def _validate_variant_weights(
+        self, genotype_matrix: np.ndarray, weights: np.ndarray | None
+    ) -> np.ndarray:
+        if weights is None:
+            raise ValueError("PythonSKATBackend requires concrete variant weights")
+        weights_arr = np.asarray(weights, dtype=np.float64)
+        n_variants = genotype_matrix.shape[1]
+        if len(weights_arr) != n_variants:
+            raise ValueError(
+                f"weights length must match genotype_matrix columns "
+                f"(got {len(weights_arr)} and {n_variants})"
+            )
+        if not np.isfinite(weights_arr).all():
+            raise ValueError("weights must be finite")
+        return weights_arr
 
     def _compute_eigenvalues_filtered(
         self,
@@ -802,7 +820,7 @@ class PythonSKATBackend(SKATBackend):
         gene: str,
         geno: np.ndarray,
         null_model: NullModelResult,
-        weights_beta: tuple[float, float],
+        weights: np.ndarray,
     ) -> dict[str, Any]:
         """
         SKAT score test for a single gene.
@@ -815,8 +833,8 @@ class PythonSKATBackend(SKATBackend):
             Genotype dosage matrix.
         null_model : NullModelResult
             Fitted null model (contains residuals and sigma2 in extra).
-        weights_beta : tuple of (float, float)
-            Beta distribution parameters (a1, a2).
+        weights : np.ndarray
+            Concrete per-variant weights aligned to genotype columns.
 
         Returns
         -------
@@ -824,7 +842,6 @@ class PythonSKATBackend(SKATBackend):
         """
         _n_samples, n_variants = geno.shape
         residuals: np.ndarray = null_model.extra["residuals"]
-        a1, a2 = weights_beta
 
         # Guard: zero-variant matrix cannot be tested
         if n_variants == 0:
@@ -854,10 +871,6 @@ class PythonSKATBackend(SKATBackend):
                 "p_converged": False,
                 "skip_reason": "rank_deficient",
             }
-
-        # Compute MAFs and Beta weights
-        mafs = geno.mean(axis=0) / 2.0
-        weights = beta_maf_weights(mafs, a=a1, b=a2)
 
         # Weighted genotype matrix via broadcasting (memory-efficient vs geno @ diag(w))
         geno_weighted = geno * weights[np.newaxis, :]
@@ -904,7 +917,7 @@ class PythonSKATBackend(SKATBackend):
         gene: str,
         geno: np.ndarray,
         null_model: NullModelResult,
-        weights_beta: tuple[float, float],
+        weights: np.ndarray,
     ) -> dict[str, Any]:
         """
         Burden score test for a single gene.
@@ -920,8 +933,8 @@ class PythonSKATBackend(SKATBackend):
             Genotype dosage matrix.
         null_model : NullModelResult
             Fitted null model.
-        weights_beta : tuple of (float, float)
-            Beta distribution parameters (a1, a2).
+        weights : np.ndarray
+            Concrete per-variant weights aligned to genotype columns.
 
         Returns
         -------
@@ -930,11 +943,6 @@ class PythonSKATBackend(SKATBackend):
         _n_samples, n_variants = geno.shape
         residuals: np.ndarray = null_model.extra["residuals"]
         sigma2: float = null_model.extra["sigma2"]
-        a1, a2 = weights_beta
-
-        # Compute MAFs and Beta weights
-        mafs = geno.mean(axis=0) / 2.0
-        weights = beta_maf_weights(mafs, a=a1, b=a2)
 
         # Collapse to burden score per sample: b = geno @ weights
         burden = geno @ weights  # shape: (n_samples,)
@@ -974,7 +982,7 @@ class PythonSKATBackend(SKATBackend):
         gene: str,
         geno: np.ndarray,
         null_model: NullModelResult,
-        weights_beta: tuple[float, float],
+        weights: np.ndarray,
     ) -> dict[str, Any]:
         """
         SKAT-O (optimal unified SKAT) for a single gene.
@@ -1003,8 +1011,8 @@ class PythonSKATBackend(SKATBackend):
             Genotype dosage matrix.
         null_model : NullModelResult
             Fitted null model.
-        weights_beta : tuple of (float, float)
-            Beta distribution parameters (a1, a2).
+        weights : np.ndarray
+            Concrete per-variant weights aligned to genotype columns.
 
         Returns
         -------
@@ -1013,7 +1021,6 @@ class PythonSKATBackend(SKATBackend):
         _n_samples, n_variants = geno.shape
         residuals: np.ndarray = null_model.extra["residuals"]
         trait_type: str = null_model.trait_type
-        a1, a2 = weights_beta
 
         # Guard: zero-variant matrix cannot be tested
         if n_variants == 0:
@@ -1043,10 +1050,6 @@ class PythonSKATBackend(SKATBackend):
                 "p_converged": False,
                 "skip_reason": "rank_deficient",
             }
-
-        # Compute weights
-        mafs = geno.mean(axis=0) / 2.0
-        weights = beta_maf_weights(mafs, a=a1, b=a2)
 
         # Weighted genotype matrix: Z = geno * weights
         geno_weighted = geno * weights[np.newaxis, :]

--- a/variantcentrifuge/association/backends/r_backend.py
+++ b/variantcentrifuge/association/backends/r_backend.py
@@ -380,7 +380,8 @@ class RSKATBackend(SKATBackend):
         genotype_matrix: np.ndarray,
         null_model: NullModelResult,
         method: str,
-        weights_beta: tuple[float, float],
+        weights: np.ndarray | None = None,
+        weights_beta: tuple[float, float] | None = None,
     ) -> dict[str, Any]:
         """
         Run SKAT for a single gene.
@@ -428,6 +429,13 @@ class RSKATBackend(SKATBackend):
             Any R-level exception propagates directly (infrastructure failure).
         """
         self._assert_main_thread()
+        if weights_beta is None and isinstance(weights, tuple):
+            weights_beta = weights
+            weights = None
+        if weights is not None:
+            raise ValueError("R SKAT backend does not support explicit variant weights")
+        if weights_beta is None:
+            weights_beta = (1.0, 25.0)
 
         import rpy2.robjects as ro
         from rpy2.rinterface import NA_Real

--- a/variantcentrifuge/association/base.py
+++ b/variantcentrifuge/association/base.py
@@ -125,6 +125,9 @@ class AssociationConfig:
     variant_weight_params: dict | None = None
     """Extra parameters for weight schemes (e.g. {'cadd_cap': 40.0})."""
 
+    variant_weight_column: str | None = None
+    """Column name used when variant_weights='score_column'. None for inline column:<name>."""
+
     missing_site_threshold: float = 0.10
     """Variants with >threshold fraction missing site-wide are excluded before imputation."""
 

--- a/variantcentrifuge/association/engine.py
+++ b/variantcentrifuge/association/engine.py
@@ -239,6 +239,16 @@ class AssociationEngine:
                     f"Test '{name}' is not available. Available tests: {', '.join(available)}"
                 )
 
+        if skat_backend == "r" and "skat" in test_names:
+            from variantcentrifuge.association.tests.skat_r import _is_r_skat_weight_supported
+
+            if not _is_r_skat_weight_supported(config.variant_weights):
+                raise ValueError(
+                    "R SKAT backend supports only beta:a,b and uniform variant weights. "
+                    f"Got '{config.variant_weights}'. Use --skat-backend python for cadd, revel, "
+                    "combined, score_column, or column:<name> weights."
+                )
+
         tests: list[AssociationTest] = []
         for name in test_names:
             test_cls = registry[name]

--- a/variantcentrifuge/association/engine.py
+++ b/variantcentrifuge/association/engine.py
@@ -113,6 +113,48 @@ def _run_gene_worker(
     return gene, results
 
 
+_BUILDER_RESULT_KEYS = (
+    "genotype_matrix",
+    "variant_mafs",
+    "phenotype_vector",
+    "covariate_matrix",
+    "score_values",
+    "variant_weight_column",
+    "cadd_scores",
+    "revel_scores",
+    "variant_effects",
+)
+
+_PER_GENE_MATRIX_PAYLOAD_KEYS = (
+    "genotype_matrix",
+    "variant_mafs",
+    "score_values",
+    "variant_weight_column",
+    "cadd_scores",
+    "revel_scores",
+    "variant_effects",
+)
+
+
+def _apply_builder_result_to_gene_data(
+    gene_data: dict[str, Any],
+    result: dict[str, Any],
+    gene: str,
+) -> None:
+    for key in _BUILDER_RESULT_KEYS:
+        if key in result:
+            gene_data[key] = result[key]
+    for warning in result.get("gt_warnings", []):
+        logger.warning(f"Gene {gene}: {warning}")
+    if result.get("mac_filtered"):
+        logger.debug(f"Gene {gene}: MAC < 5 — regression will report NA")
+
+
+def _discard_per_gene_matrix_payload(gene_data: dict[str, Any]) -> None:
+    for key in _PER_GENE_MATRIX_PAYLOAD_KEYS:
+        gene_data.pop(key, None)
+
+
 class AssociationEngine:
     """
     Orchestrates association testing across multiple genes and multiple tests.
@@ -380,14 +422,7 @@ class AssociationEngine:
             ):
                 _builder = first_gene_data.pop("_genotype_matrix_builder")
                 _result = _builder()
-                first_gene_data["genotype_matrix"] = _result["genotype_matrix"]
-                first_gene_data["variant_mafs"] = _result["variant_mafs"]
-                first_gene_data["phenotype_vector"] = _result["phenotype_vector"]
-                first_gene_data["covariate_matrix"] = _result["covariate_matrix"]
-                for _w in _result.get("gt_warnings", []):
-                    logger.warning(f"Gene {first_gene}: {_w}")
-                if _result.get("mac_filtered"):
-                    logger.debug(f"Gene {first_gene}: MAC < 5 — regression will report NA")
+                _apply_builder_result_to_gene_data(first_gene_data, _result, first_gene)
 
             for test_name, test in self._tests.items():
                 result = test.run(first_gene, first_gene_data, self._config)
@@ -397,8 +432,7 @@ class AssociationEngine:
                 )
 
             # PERF-06: Discard first gene matrix after tests complete
-            first_gene_data.pop("genotype_matrix", None)
-            first_gene_data.pop("variant_mafs", None)
+            _discard_per_gene_matrix_payload(first_gene_data)
 
             # Pickle test instances now that null models are fitted
             import concurrent.futures
@@ -426,15 +460,8 @@ class AssociationEngine:
                     if "_genotype_matrix_builder" in gd and "genotype_matrix" not in gd:
                         _builder = gd.pop("_genotype_matrix_builder")
                         _result = _builder()
-                        gd["genotype_matrix"] = _result["genotype_matrix"]
-                        gd["variant_mafs"] = _result["variant_mafs"]
-                        gd["phenotype_vector"] = _result["phenotype_vector"]
-                        gd["covariate_matrix"] = _result["covariate_matrix"]
                         _gene = gd.get("GENE", "")
-                        for _w in _result.get("gt_warnings", []):
-                            logger.warning(f"Gene {_gene}: {_w}")
-                        if _result.get("mac_filtered"):
-                            logger.debug(f"Gene {_gene}: MAC < 5 — regression will report NA")
+                        _apply_builder_result_to_gene_data(gd, _result, _gene)
 
                 args_list = [
                     (gd.get("GENE", ""), gd, pickled_tests, self._config) for gd in remaining
@@ -453,8 +480,7 @@ class AssociationEngine:
 
                 # PERF-06: Discard matrices after parallel batch completes
                 for gd in remaining:
-                    gd.pop("genotype_matrix", None)
-                    gd.pop("variant_mafs", None)
+                    _discard_per_gene_matrix_payload(gd)
         else:
             # Sequential gene loop (default path or fallback)
             for gene_data in sorted_data:
@@ -464,14 +490,7 @@ class AssociationEngine:
                 if "_genotype_matrix_builder" in gene_data and "genotype_matrix" not in gene_data:
                     builder = gene_data.pop("_genotype_matrix_builder")
                     result = builder()
-                    gene_data["genotype_matrix"] = result["genotype_matrix"]
-                    gene_data["variant_mafs"] = result["variant_mafs"]
-                    gene_data["phenotype_vector"] = result["phenotype_vector"]
-                    gene_data["covariate_matrix"] = result["covariate_matrix"]
-                    for w in result.get("gt_warnings", []):
-                        logger.warning(f"Gene {gene}: {w}")
-                    if result.get("mac_filtered"):
-                        logger.debug(f"Gene {gene}: MAC < 5 — regression will report NA")
+                    _apply_builder_result_to_gene_data(gene_data, result, gene)
 
                 for test_name, test in self._tests.items():
                     result = test.run(gene, gene_data, self._config)
@@ -481,8 +500,7 @@ class AssociationEngine:
                     )
 
                 # PERF-06: Discard matrix after all tests for this gene complete
-                gene_data.pop("genotype_matrix", None)
-                gene_data.pop("variant_mafs", None)
+                _discard_per_gene_matrix_payload(gene_data)
                 # Keep phenotype_vector and covariate_matrix — shared references, not per-gene
 
         # Lifecycle hook: finalize() after gene loop (allows timing summary, cleanup)

--- a/variantcentrifuge/association/genotype_matrix.py
+++ b/variantcentrifuge/association/genotype_matrix.py
@@ -170,9 +170,10 @@ def build_genotype_matrix(
     missing_sample_threshold: float = 0.80,
     phenotype_vector: np.ndarray | None = None,
     return_keep_mask: bool = False,
-) -> tuple[np.ndarray, np.ndarray, list[bool], list[str]] | tuple[
-    np.ndarray, np.ndarray, list[bool], list[str], np.ndarray
-]:
+) -> (
+    tuple[np.ndarray, np.ndarray, list[bool], list[str]]
+    | tuple[np.ndarray, np.ndarray, list[bool], list[str], np.ndarray]
+):
     """
     Build a fully imputed genotype matrix from a per-gene variant DataFrame.
 

--- a/variantcentrifuge/association/genotype_matrix.py
+++ b/variantcentrifuge/association/genotype_matrix.py
@@ -169,7 +169,10 @@ def build_genotype_matrix(
     missing_site_threshold: float = 0.10,
     missing_sample_threshold: float = 0.80,
     phenotype_vector: np.ndarray | None = None,
-) -> tuple[np.ndarray, np.ndarray, list[bool], list[str]]:
+    return_keep_mask: bool = False,
+) -> tuple[np.ndarray, np.ndarray, list[bool], list[str]] | tuple[
+    np.ndarray, np.ndarray, list[bool], list[str], np.ndarray
+]:
     """
     Build a fully imputed genotype matrix from a per-gene variant DataFrame.
 
@@ -198,6 +201,9 @@ def build_genotype_matrix(
     phenotype_vector : np.ndarray | None, shape (n_samples,)
         Optional binary phenotype (0/1). When provided, differential
         missingness warnings are computed per variant. Ignored if None.
+    return_keep_mask : bool
+        When True, append the site-level variant keep mask as a fifth return value.
+        Default False preserves the historical four-tuple return.
 
     Returns
     -------
@@ -216,6 +222,8 @@ def build_genotype_matrix(
     warnings_list : list[str]
         Diagnostic messages accumulated during construction (e.g. multi-
         allelic detection, differential missingness).
+    keep_variants_mask : np.ndarray, optional
+        Boolean mask over input rows, returned only when ``return_keep_mask=True``.
 
     Notes
     -----
@@ -310,4 +318,6 @@ def build_genotype_matrix(
     # ------------------------------------------------------------------ #
     geno = geno.T  # shape (n_samples, n_kept_variants)
 
+    if return_keep_mask:
+        return geno, mafs, sample_mask, warnings_list, keep_variants_mask
     return geno, mafs, sample_mask, warnings_list

--- a/variantcentrifuge/association/tests/linear_burden.py
+++ b/variantcentrifuge/association/tests/linear_burden.py
@@ -157,6 +157,7 @@ class LinearBurdenTest(AssociationTest):
             config.variant_weights,
             cadd_scores=contingency_data.get("cadd_scores"),
             revel_scores=contingency_data.get("revel_scores"),
+            score_values=contingency_data.get("score_values"),
             variant_effects=contingency_data.get("variant_effects"),
             weight_params=config.variant_weight_params,
         )

--- a/variantcentrifuge/association/tests/logistic_burden.py
+++ b/variantcentrifuge/association/tests/logistic_burden.py
@@ -335,6 +335,7 @@ class LogisticBurdenTest(AssociationTest):
             config.variant_weights,
             cadd_scores=contingency_data.get("cadd_scores"),
             revel_scores=contingency_data.get("revel_scores"),
+            score_values=contingency_data.get("score_values"),
             variant_effects=contingency_data.get("variant_effects"),
             weight_params=config.variant_weight_params,
         )

--- a/variantcentrifuge/association/tests/skat_python.py
+++ b/variantcentrifuge/association/tests/skat_python.py
@@ -45,9 +45,8 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from variantcentrifuge.association.base import AssociationConfig, AssociationTest, TestResult
-from variantcentrifuge.association.tests._utils import parse_weights_beta
 from variantcentrifuge.association.tests.acat import compute_acat_v
-from variantcentrifuge.association.weights import beta_maf_weights
+from variantcentrifuge.association.weights import get_weights
 
 if TYPE_CHECKING:
     from variantcentrifuge.association.backends.base import NullModelResult
@@ -263,22 +262,28 @@ class PurePythonSKATTest(AssociationTest):
                 trait_type=config.trait_type,
             )
 
-        # Parse weight parameters from config (e.g. "beta:1,25" -> (1.0, 25.0))
-        weights_beta = parse_weights_beta(config.variant_weights)
+        skat_mafs = geno.mean(axis=0) / 2.0
+        weights = get_weights(
+            skat_mafs,
+            config.variant_weights,
+            cadd_scores=contingency_data.get("cadd_scores"),
+            revel_scores=contingency_data.get("revel_scores"),
+            score_values=contingency_data.get("score_values"),
+            variant_effects=contingency_data.get("variant_effects"),
+            weight_params=config.variant_weight_params,
+        )
 
         result = self._backend.test_gene(
             gene=gene,
             genotype_matrix=geno,
             null_model=self._null_model,
             method=config.skat_method,
-            weights_beta=weights_beta,
+            weights=weights,
         )
 
         # Compute ACAT-V per-variant score test (Phase 25)
-        # Uses same Beta(MAF) weights as SKAT for consistency.
-        mafs = geno.mean(axis=0) / 2.0
-        a1, a2 = weights_beta
-        acat_v_weights = beta_maf_weights(mafs, a=a1, b=a2)
+        # Uses the same resolved variant weights as SKAT for consistency.
+        acat_v_weights = weights
         acat_v_p = compute_acat_v(
             geno=geno,
             residuals=self._null_model.extra["residuals"],

--- a/variantcentrifuge/association/tests/skat_r.py
+++ b/variantcentrifuge/association/tests/skat_r.py
@@ -269,6 +269,9 @@ class RSKATTest(AssociationTest):
                 extra={"skat_warnings": ["NO_PHENOTYPE_OR_EMPTY_MATRIX"]},
             )
 
+        if not _is_r_skat_weight_supported(config.variant_weights):
+            _raise_unsupported_r_skat_weight(config.variant_weights)
+
         # Backend must have been initialised by check_dependencies()
         if self._backend is None:
             raise RuntimeError(
@@ -364,3 +367,15 @@ def _parse_weights_beta(variant_weights: str) -> tuple[float, float]:
     (1.0, 1.0)
     """
     return _parse_weights_beta_shared(variant_weights)
+
+
+def _is_r_skat_weight_supported(variant_weights: str) -> bool:
+    return variant_weights == "uniform" or variant_weights.startswith("beta:")
+
+
+def _raise_unsupported_r_skat_weight(variant_weights: str) -> None:
+    raise ValueError(
+        "R SKAT backend supports only beta:a,b and uniform variant weights. "
+        f"Got '{variant_weights}'. Use --skat-backend python for cadd, revel, "
+        "combined, score_column, or column:<name> weights."
+    )

--- a/variantcentrifuge/association/weights.py
+++ b/variantcentrifuge/association/weights.py
@@ -14,6 +14,8 @@ Provides public functions:
   REVEL scores. REVEL is already in [0, 1]; no normalization needed.
 - ``combined_weights``: Beta(MAF) x functional score. Uses CADD by default;
   falls back to REVEL if CADD is not provided.
+- ``score_column_weights``: Beta(MAF) x arbitrary numeric score-column weights,
+  or raw normalized score weights when combine_with_beta is false.
 - ``get_weights``: String-spec parser that dispatches to any of the above.
 
 Weight spec string format
@@ -134,6 +136,95 @@ def _parse_scores_to_float(scores: np.ndarray | None) -> np.ndarray | None:
             except (ValueError, TypeError):
                 result[i] = np.nan
     return result
+
+
+def resolve_score_weight_column(
+    weight_spec: str,
+    variant_weight_column: str | None = None,
+) -> str | None:
+    """Resolve a score-column weight spec to a DataFrame column name."""
+    if weight_spec.startswith("column:"):
+        inline_column = weight_spec[len("column:") :].strip()
+        if not inline_column:
+            raise ValueError("column:<name> requires a non-empty column name")
+        if variant_weight_column:
+            logger.debug(
+                "variant_weights=%r includes inline column %r; ignoring variant_weight_column=%r",
+                weight_spec,
+                inline_column,
+                variant_weight_column,
+            )
+        return inline_column
+
+    if weight_spec == "score_column":
+        if not variant_weight_column:
+            raise ValueError("score_column requires variant_weight_column")
+        return variant_weight_column
+
+    return None
+
+
+_SCORE_WEIGHT_DEFAULTS = {
+    "score_min": None,
+    "score_max": None,
+    "floor": 0.0,
+    "ceiling": 1.0,
+    "combine_with_beta": True,
+    "missing": None,
+    "beta_a": 1.0,
+    "beta_b": 25.0,
+}
+
+
+def _normalize_score_weight_params(weight_params: dict | None) -> dict:
+    if weight_params is not None and not isinstance(weight_params, dict):
+        raise ValueError(
+            f"variant_weight_params must be a dict, got {type(weight_params).__name__}"
+        )
+
+    params = dict(_SCORE_WEIGHT_DEFAULTS)
+    params.update(weight_params or {})
+
+    score_min = params["score_min"]
+    score_max = params["score_max"]
+    if (score_min is None) != (score_max is None):
+        raise ValueError("score_min and score_max must be provided together")
+    if score_min is not None and float(score_min) >= float(score_max):
+        raise ValueError("score_min must be less than score_max")
+
+    floor = float(params["floor"])
+    ceiling = float(params["ceiling"])
+    if floor < 0:
+        raise ValueError("floor must be >= 0")
+    if ceiling <= 0:
+        raise ValueError("ceiling must be > 0")
+    if floor > ceiling:
+        raise ValueError("floor must be <= ceiling")
+
+    beta_a = float(params["beta_a"])
+    beta_b = float(params["beta_b"])
+    if beta_a <= 0:
+        raise ValueError("beta_a must be > 0")
+    if beta_b <= 0:
+        raise ValueError("beta_b must be > 0")
+
+    missing = params["missing"]
+    if missing not in (None, "neutral", "floor"):
+        raise ValueError("missing must be one of None, 'neutral', or 'floor'")
+
+    combine_with_beta = bool(params["combine_with_beta"])
+    if missing == "neutral" and not combine_with_beta:
+        raise ValueError("missing='neutral' is invalid when combine_with_beta=false")
+
+    params["floor"] = floor
+    params["ceiling"] = ceiling
+    params["beta_a"] = beta_a
+    params["beta_b"] = beta_b
+    params["combine_with_beta"] = combine_with_beta
+    if score_min is not None:
+        params["score_min"] = float(score_min)
+        params["score_max"] = float(score_max)
+    return params
 
 
 def _log_missing_score_counts(
@@ -259,6 +350,69 @@ def revel_weights(
     return np.asarray(maf_w * functional, dtype=np.float64)
 
 
+def score_column_weights(
+    mafs: np.ndarray,
+    score_values: np.ndarray,
+    *,
+    variant_effects: np.ndarray | None = None,
+    weight_params: dict | None = None,
+) -> np.ndarray:
+    """Compute weights from an arbitrary numeric variant score column."""
+    mafs_arr = np.asarray(mafs, dtype=np.float64)
+    scores_f = _parse_scores_to_float(np.asarray(score_values, dtype=object))
+    assert scores_f is not None
+
+    if len(mafs_arr) != len(scores_f):
+        raise ValueError(
+            f"score_values and mafs must have the same length "
+            f"(got {len(scores_f)} and {len(mafs_arr)})"
+        )
+
+    params = _normalize_score_weight_params(weight_params)
+    finite_mask = np.isfinite(scores_f)
+    missing_mask = ~finite_mask
+
+    normalized = np.empty(len(scores_f), dtype=np.float64)
+    normalized[:] = np.nan
+
+    if params["score_min"] is not None:
+        score_min = float(params["score_min"])
+        score_max = float(params["score_max"])
+        normalized[finite_mask] = (scores_f[finite_mask] - score_min) / (
+            score_max - score_min
+        )
+    else:
+        normalized[finite_mask] = scores_f[finite_mask]
+        out_of_unit = finite_mask & ((scores_f < 0.0) | (scores_f > 1.0))
+        if bool(out_of_unit.any()):
+            logger.warning(
+                "score_column weights: %d finite score(s) outside [0, 1] without explicit range",
+                int(out_of_unit.sum()),
+            )
+
+    functional = np.clip(normalized, params["floor"], params["ceiling"])
+
+    missing_mode = params["missing"]
+    if missing_mode is None:
+        missing_mode = "neutral" if params["combine_with_beta"] else "floor"
+
+    if missing_mode == "neutral":
+        functional[missing_mask] = 1.0
+    else:
+        functional[missing_mask] = params["floor"]
+
+    _log_missing_score_counts(missing_mask, variant_effects, "score_column")
+
+    if bool(missing_mask.all()) and len(missing_mask) > 0:
+        logger.warning("score_column weights: all score values for this gene are missing or invalid")
+
+    if params["combine_with_beta"]:
+        maf_w = beta_maf_weights(mafs_arr, a=params["beta_a"], b=params["beta_b"])
+        return np.asarray(maf_w * functional, dtype=np.float64)
+
+    return np.asarray(functional, dtype=np.float64)
+
+
 def combined_weights(
     mafs: np.ndarray,
     cadd_scores: np.ndarray | None = None,
@@ -308,6 +462,7 @@ def get_weights(
     *,
     cadd_scores: np.ndarray | None = None,
     revel_scores: np.ndarray | None = None,
+    score_values: np.ndarray | None = None,
     variant_effects: np.ndarray | None = None,
     weight_params: dict | None = None,
 ) -> np.ndarray:
@@ -380,6 +535,18 @@ def get_weights(
             ) from err
         return beta_maf_weights(mafs_arr, a=a, b=b)
 
+    if weight_spec == "score_column" or weight_spec.startswith("column:"):
+        if weight_spec.startswith("column:") and not weight_spec[len("column:") :].strip():
+            raise ValueError("column:<name> requires a non-empty column name")
+        if score_values is None:
+            raise ValueError(f"weight_spec='{weight_spec}' requires score_values to be provided")
+        return score_column_weights(
+            mafs_arr,
+            score_values,
+            variant_effects=variant_effects,
+            weight_params=weight_params,
+        )
+
     if weight_spec == "cadd":
         if cadd_scores is None:
             raise ValueError(
@@ -409,5 +576,6 @@ def get_weights(
 
     raise ValueError(
         f"Unknown weight spec '{weight_spec}'. Supported specs: "
-        "'beta:a,b', 'uniform', 'cadd', 'revel', 'combined'."
+        "'beta:a,b', 'uniform', 'cadd', 'revel', 'combined', "
+        "'column:<name>', 'score_column'."
     )

--- a/variantcentrifuge/association/weights.py
+++ b/variantcentrifuge/association/weights.py
@@ -277,6 +277,38 @@ def _log_missing_score_counts(
     )
 
 
+def _log_missing_score_column_counts(
+    missing_mask: np.ndarray,
+    variant_effects: np.ndarray | None,
+    fallback_description: str,
+) -> None:
+    """Log missing score-column counts without implying functional-score semantics."""
+    n_missing = int(missing_mask.sum())
+    if n_missing == 0:
+        return
+
+    prefix = f"score_column weights: {n_missing} variant(s) had missing or invalid scores"
+    if variant_effects is None:
+        logger.warning("%s (used %s fallback)", prefix, fallback_description)
+        return
+
+    effects_arr = np.asarray(variant_effects, dtype=object)
+    missing_effects = effects_arr[missing_mask]
+
+    n_lof = int(sum(1 for e in missing_effects if e in LOF_EFFECTS))
+    n_miss = int(sum(1 for e in missing_effects if e in MISSENSE_EFFECTS))
+    n_other = n_missing - n_lof - n_miss
+
+    logger.warning(
+        "%s — %d LoF, %d missense, %d other (used %s fallback)",
+        prefix,
+        n_lof,
+        n_miss,
+        n_other,
+        fallback_description,
+    )
+
+
 def cadd_weights(
     mafs: np.ndarray,
     cadd_scores: np.ndarray,
@@ -402,10 +434,12 @@ def score_column_weights(
 
     if missing_mode == "neutral":
         functional[missing_mask] = 1.0
+        missing_fallback = "neutral weight 1.0"
     else:
         functional[missing_mask] = params["floor"]
+        missing_fallback = f"floor={params['floor']}"
 
-    _log_missing_score_counts(missing_mask, variant_effects, "score_column")
+    _log_missing_score_column_counts(missing_mask, variant_effects, missing_fallback)
 
     if bool(missing_mask.all()) and len(missing_mask) > 0:
         logger.warning(

--- a/variantcentrifuge/association/weights.py
+++ b/variantcentrifuge/association/weights.py
@@ -48,6 +48,7 @@ A warning is logged listing per-category missing counts.
 from __future__ import annotations
 
 import logging
+from typing import Any, cast
 
 import numpy as np
 from scipy.stats import beta as _beta_dist
@@ -189,11 +190,16 @@ def _normalize_score_weight_params(weight_params: dict | None) -> dict:
     score_max = params["score_max"]
     if (score_min is None) != (score_max is None):
         raise ValueError("score_min and score_max must be provided together")
-    if score_min is not None and float(score_min) >= float(score_max):
-        raise ValueError("score_min must be less than score_max")
+    score_min_f: float | None = None
+    score_max_f: float | None = None
+    if score_min is not None:
+        score_min_f = float(cast(Any, score_min))
+        score_max_f = float(cast(Any, score_max))
+        if score_min_f >= score_max_f:
+            raise ValueError("score_min must be less than score_max")
 
-    floor = float(params["floor"])
-    ceiling = float(params["ceiling"])
+    floor = float(cast(Any, params["floor"]))
+    ceiling = float(cast(Any, params["ceiling"]))
     if floor < 0:
         raise ValueError("floor must be >= 0")
     if ceiling <= 0:
@@ -201,8 +207,8 @@ def _normalize_score_weight_params(weight_params: dict | None) -> dict:
     if floor > ceiling:
         raise ValueError("floor must be <= ceiling")
 
-    beta_a = float(params["beta_a"])
-    beta_b = float(params["beta_b"])
+    beta_a = float(cast(Any, params["beta_a"]))
+    beta_b = float(cast(Any, params["beta_b"]))
     if beta_a <= 0:
         raise ValueError("beta_a must be > 0")
     if beta_b <= 0:
@@ -221,9 +227,9 @@ def _normalize_score_weight_params(weight_params: dict | None) -> dict:
     params["beta_a"] = beta_a
     params["beta_b"] = beta_b
     params["combine_with_beta"] = combine_with_beta
-    if score_min is not None:
-        params["score_min"] = float(score_min)
-        params["score_max"] = float(score_max)
+    if score_min_f is not None:
+        params["score_min"] = score_min_f
+        params["score_max"] = score_max_f
     return params
 
 
@@ -378,9 +384,7 @@ def score_column_weights(
     if params["score_min"] is not None:
         score_min = float(params["score_min"])
         score_max = float(params["score_max"])
-        normalized[finite_mask] = (scores_f[finite_mask] - score_min) / (
-            score_max - score_min
-        )
+        normalized[finite_mask] = (scores_f[finite_mask] - score_min) / (score_max - score_min)
     else:
         normalized[finite_mask] = scores_f[finite_mask]
         out_of_unit = finite_mask & ((scores_f < 0.0) | (scores_f > 1.0))
@@ -404,7 +408,9 @@ def score_column_weights(
     _log_missing_score_counts(missing_mask, variant_effects, "score_column")
 
     if bool(missing_mask.all()) and len(missing_mask) > 0:
-        logger.warning("score_column weights: all score values for this gene are missing or invalid")
+        logger.warning(
+            "score_column weights: all score values for this gene are missing or invalid"
+        )
 
     if params["combine_with_beta"]:
         maf_w = beta_maf_weights(mafs_arr, a=params["beta_a"], b=params["beta_b"])

--- a/variantcentrifuge/cli.py
+++ b/variantcentrifuge/cli.py
@@ -1269,9 +1269,7 @@ def main() -> int:
         try:
             parsed_params = _json.loads(_vwp_raw)
             if not isinstance(parsed_params, dict):
-                raise TypeError(
-                    f"expected a JSON object, got {type(parsed_params).__name__}"
-                )
+                raise TypeError(f"expected a JSON object, got {type(parsed_params).__name__}")
             cfg["variant_weight_params"] = parsed_params
         except (ValueError, TypeError) as _e:
             import sys as _sys
@@ -1546,9 +1544,10 @@ def main() -> int:
             args, "variant_weight_column", None
         ):
             parser.error("--variant-weight-column is required when --variant-weights score_column")
-        if variant_weights_arg.startswith("column:") and not variant_weights_arg[
-            len("column:") :
-        ].strip():
+        if (
+            variant_weights_arg.startswith("column:")
+            and not variant_weights_arg[len("column:") :].strip()
+        ):
             parser.error("--variant-weights column:<name> requires a non-empty column name")
 
     # Covariate file only makes sense with association analysis

--- a/variantcentrifuge/cli.py
+++ b/variantcentrifuge/cli.py
@@ -512,6 +512,15 @@ def create_parser() -> argparse.ArgumentParser:
         ),
     )
     stats_group.add_argument(
+        "--variant-weight-column",
+        type=str,
+        default=None,
+        help=(
+            "Variant-level numeric score column to use when --variant-weights score_column "
+            "is set. Ignored when --variant-weights uses inline column:<name>."
+        ),
+    )
+    stats_group.add_argument(
         "--variant-weight-params",
         type=str,
         default=None,
@@ -1251,13 +1260,19 @@ def main() -> int:
     )
     cfg["trait_type"] = getattr(args, "trait_type", "binary")
     cfg["variant_weights"] = getattr(args, "variant_weights", "beta:1,25")
+    cfg["variant_weight_column"] = getattr(args, "variant_weight_column", None)
     # Phase 23: Parse --variant-weight-params JSON string
     _vwp_raw = getattr(args, "variant_weight_params", None)
     if _vwp_raw:
         import json as _json
 
         try:
-            cfg["variant_weight_params"] = _json.loads(_vwp_raw)
+            parsed_params = _json.loads(_vwp_raw)
+            if not isinstance(parsed_params, dict):
+                raise TypeError(
+                    f"expected a JSON object, got {type(parsed_params).__name__}"
+                )
+            cfg["variant_weight_params"] = parsed_params
         except (ValueError, TypeError) as _e:
             import sys as _sys
 
@@ -1521,6 +1536,20 @@ def main() -> int:
     # Validate association analysis arguments
     if args.association_tests and not args.perform_association:
         parser.error("--association-tests requires --perform-association to be set")
+
+    if getattr(args, "variant_weight_column", None) and not args.perform_association:
+        parser.error("--variant-weight-column requires --perform-association to be set")
+
+    if args.perform_association:
+        variant_weights_arg = getattr(args, "variant_weights", "beta:1,25")
+        if variant_weights_arg == "score_column" and not getattr(
+            args, "variant_weight_column", None
+        ):
+            parser.error("--variant-weight-column is required when --variant-weights score_column")
+        if variant_weights_arg.startswith("column:") and not variant_weights_arg[
+            len("column:") :
+        ].strip():
+            parser.error("--variant-weights column:<name> requires a non-empty column name")
 
     # Covariate file only makes sense with association analysis
     if getattr(args, "covariate_file", None) and not args.perform_association:

--- a/variantcentrifuge/stages/analysis_stages.py
+++ b/variantcentrifuge/stages/analysis_stages.py
@@ -57,6 +57,44 @@ class _GenotypeMatrixBuilder:
     missing_sample_threshold: float
     phenotype_vector: "np.ndarray | None"
     covariate_matrix: "np.ndarray | None"
+    score_column: str | None = None
+    cadd_column: str | None = None
+    revel_column: str | None = None
+    effect_column: str | None = None
+
+    def _aligned_annotation_payload(self, keep_variants_mask: np.ndarray) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        if self.score_column is not None:
+            payload["score_values"] = self.gene_df[self.score_column].to_numpy(dtype=object)[
+                keep_variants_mask
+            ]
+            payload["variant_weight_column"] = self.score_column
+        if self.cadd_column is not None:
+            payload["cadd_scores"] = self.gene_df[self.cadd_column].to_numpy(dtype=object)[
+                keep_variants_mask
+            ]
+        if self.revel_column is not None:
+            payload["revel_scores"] = self.gene_df[self.revel_column].to_numpy(dtype=object)[
+                keep_variants_mask
+            ]
+        if self.effect_column is not None:
+            payload["variant_effects"] = self.gene_df[self.effect_column].to_numpy(dtype=object)[
+                keep_variants_mask
+            ]
+        return payload
+
+    def _empty_annotation_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        if self.score_column is not None:
+            payload["score_values"] = np.asarray([], dtype=object)
+            payload["variant_weight_column"] = self.score_column
+        if self.cadd_column is not None:
+            payload["cadd_scores"] = np.asarray([], dtype=object)
+        if self.revel_column is not None:
+            payload["revel_scores"] = np.asarray([], dtype=object)
+        if self.effect_column is not None:
+            payload["variant_effects"] = np.asarray([], dtype=object)
+        return payload
 
     def __call__(self) -> dict[str, Any]:
         """Build genotype matrix and apply sample mask + MAC check.
@@ -68,7 +106,7 @@ class _GenotypeMatrixBuilder:
 
         if self.gene_df.empty:
             n_samples = len(self.vcf_samples)
-            return {
+            result = {
                 "genotype_matrix": np.zeros((n_samples, 0), dtype=float),
                 "variant_mafs": np.zeros(0, dtype=float),
                 "phenotype_vector": self.phenotype_vector,
@@ -76,8 +114,10 @@ class _GenotypeMatrixBuilder:
                 "gt_warnings": [],
                 "mac_filtered": False,
             }
+            result.update(self._empty_annotation_payload())
+            return result
 
-        geno, mafs, sample_mask, gt_warnings = build_genotype_matrix(
+        geno, mafs, sample_mask, gt_warnings, keep_variants_mask = build_genotype_matrix(
             self.gene_df,
             self.vcf_samples,
             self.gt_columns,
@@ -85,7 +125,9 @@ class _GenotypeMatrixBuilder:
             missing_site_threshold=self.missing_site_threshold,
             missing_sample_threshold=self.missing_sample_threshold,
             phenotype_vector=self.phenotype_vector,
+            return_keep_mask=True,
         )
+        annotation_payload = self._aligned_annotation_payload(keep_variants_mask)
 
         # Apply sample mask to phenotype and covariates
         pv = self.phenotype_vector
@@ -102,9 +144,10 @@ class _GenotypeMatrixBuilder:
         if total_mac < 5:
             geno = np.zeros((geno.shape[0], 0), dtype=float)
             mafs = np.zeros(0, dtype=float)
+            annotation_payload = self._empty_annotation_payload()
             mac_filtered = True
 
-        return {
+        result = {
             "genotype_matrix": geno,
             "variant_mafs": mafs,
             "phenotype_vector": pv,
@@ -112,6 +155,8 @@ class _GenotypeMatrixBuilder:
             "gt_warnings": gt_warnings,
             "mac_filtered": mac_filtered,
         }
+        result.update(annotation_payload)
+        return result
 
 
 # Standard column aliases: sanitized name -> canonical short name.

--- a/variantcentrifuge/stages/analysis_stages.py
+++ b/variantcentrifuge/stages/analysis_stages.py
@@ -107,7 +107,7 @@ class _GenotypeMatrixBuilder:
 
         if self.gene_df.empty:
             n_samples = len(self.vcf_samples)
-            result = {
+            result: dict[str, Any] = {
                 "genotype_matrix": np.zeros((n_samples, 0), dtype=float),
                 "variant_mafs": np.zeros(0, dtype=float),
                 "phenotype_vector": self.phenotype_vector,
@@ -118,15 +118,18 @@ class _GenotypeMatrixBuilder:
             result.update(self._empty_annotation_payload())
             return result
 
-        geno, mafs, sample_mask, gt_warnings, keep_variants_mask = build_genotype_matrix(
-            self.gene_df,
-            self.vcf_samples,
-            self.gt_columns,
-            is_binary=self.is_binary,
-            missing_site_threshold=self.missing_site_threshold,
-            missing_sample_threshold=self.missing_sample_threshold,
-            phenotype_vector=self.phenotype_vector,
-            return_keep_mask=True,
+        geno, mafs, sample_mask, gt_warnings, keep_variants_mask = cast(
+            tuple[np.ndarray, np.ndarray, list[bool], list[str], np.ndarray],
+            build_genotype_matrix(
+                self.gene_df,
+                self.vcf_samples,
+                self.gt_columns,
+                is_binary=self.is_binary,
+                missing_site_threshold=self.missing_site_threshold,
+                missing_sample_threshold=self.missing_sample_threshold,
+                phenotype_vector=self.phenotype_vector,
+                return_keep_mask=True,
+            ),
         )
         annotation_payload = self._aligned_annotation_payload(keep_variants_mask)
 
@@ -2103,10 +2106,7 @@ class GeneBurdenAnalysisStage(Stage):
             context.config["gene_burden_output"] = burden_output
 
         # Treat gene burden as a user-facing sidecar output, not an intermediate.
-        if str(burden_output).endswith(".gz"):
-            compression = "gzip"
-        else:
-            compression = None
+        compression = "gzip" if str(burden_output).endswith(".gz") else None
 
         burden_results.to_csv(
             burden_output, sep="\t", index=False, compression=cast(Any, compression)

--- a/variantcentrifuge/stages/analysis_stages.py
+++ b/variantcentrifuge/stages/analysis_stages.py
@@ -24,6 +24,7 @@ from ..analyze_variants import analyze_variants
 from ..annotator import annotate_dataframe_with_features, load_custom_features
 from ..association.base import AssociationConfig
 from ..association.engine import AssociationEngine
+from ..association.weights import resolve_score_weight_column
 from ..dataframe_optimizer import load_optimized_dataframe, should_use_memory_passthrough
 from ..gene_burden import (
     _aggregate_gene_burden_from_columns,
@@ -157,6 +158,18 @@ class _GenotypeMatrixBuilder:
         }
         result.update(annotation_payload)
         return result
+
+
+def _find_cadd_column(df: pd.DataFrame) -> str | None:
+    return next((c for c in df.columns if c.lower() in ("dbnsfp_cadd_phred", "cadd_phred")), None)
+
+
+def _find_revel_column(df: pd.DataFrame) -> str | None:
+    return next((c for c in df.columns if c.lower() in ("dbnsfp_revel_score", "revel_score")), None)
+
+
+def _find_effect_column(df: pd.DataFrame) -> str | None:
+    return next((c for c in df.columns if c.upper() in ("EFFECT", "ANN_0__EFFECT")), None)
 
 
 # Standard column aliases: sanitized name -> canonical short name.
@@ -2537,6 +2550,22 @@ class AssociationAnalysisStage(Stage):
             logger.error("DataFrame missing required 'GENE' column for association analysis")
             return context
 
+        score_weight_column = resolve_score_weight_column(
+            assoc_config.variant_weights,
+            assoc_config.variant_weight_column,
+        )
+        if score_weight_column is not None and score_weight_column not in df.columns:
+            raise ValueError(
+                f"Requested variant weight column '{score_weight_column}' is missing from "
+                "the association input DataFrame."
+            )
+
+        needs_functional_annotations = assoc_config.variant_weights in {
+            "cadd",
+            "revel",
+            "combined",
+        }
+
         # Phase 24/31: Validate required columns for COAST allelic series test.
         # COAST needs annotation columns to classify variants into BMV/DMV/PTV.
         # Required columns depend on the classification model selected:
@@ -2769,6 +2798,14 @@ class AssociationAnalysisStage(Stage):
                 except KeyError:
                     gene_df = gt_source_df.iloc[0:0]
 
+                cadd_column = _find_cadd_column(gene_df) if needs_functional_annotations else None
+                revel_column = _find_revel_column(gene_df) if needs_functional_annotations else None
+                effect_column = (
+                    _find_effect_column(gene_df)
+                    if needs_functional_annotations or score_weight_column is not None
+                    else None
+                )
+
                 # Store lazy builder instead of pre-built matrix (PERF-06)
                 builder = _GenotypeMatrixBuilder(
                     gene_df=gene_df,
@@ -2779,74 +2816,12 @@ class AssociationAnalysisStage(Stage):
                     missing_sample_threshold=assoc_config.missing_sample_threshold,
                     phenotype_vector=phenotype_vector,
                     covariate_matrix=covariate_matrix,
+                    score_column=score_weight_column,
+                    cadd_column=cadd_column,
+                    revel_column=revel_column,
+                    effect_column=effect_column,
                 )
                 gene_data["_genotype_matrix_builder"] = builder
-
-                # Phase 23: Extract functional annotation columns for CADD/REVEL weight schemes
-                # (WEIGHT-05). Arrays must align with variant_mafs (post site-filter length).
-                # Annotation extraction is cheap and needed regardless of lazy building.
-                if assoc_config.variant_weights in ("cadd", "revel", "combined"):
-                    _cadd_col = next(
-                        (
-                            c
-                            for c in gene_df.columns
-                            if c.lower() in ("dbnsfp_cadd_phred", "cadd_phred")
-                        ),
-                        None,
-                    )
-                    _revel_col = next(
-                        (
-                            c
-                            for c in gene_df.columns
-                            if c.lower() in ("dbnsfp_revel_score", "revel_score")
-                        ),
-                        None,
-                    )
-                    _effect_col = next(
-                        (c for c in gene_df.columns if c.upper() in ("EFFECT", "ANN_0__EFFECT")),
-                        None,
-                    )
-                    # Align annotations with variant_mafs (build_genotype_matrix applies
-                    # a site missing-rate filter; replicate it here for correct alignment).
-                    # Vectorized: count missing GTs per variant using pandas isin() instead
-                    # of per-cell parse_gt_to_dosage() calls.
-                    _gt_cols_list = list(gt_columns_for_matrix)
-                    _n_samples_gt = len(_gt_cols_list)
-                    _n_df = len(gene_df)
-                    if _n_df > 0 and _n_samples_gt > 0:
-                        # Missing GT values: ./., .|., ., empty, None, partial (./1, 1/.)
-                        # Vectorized: count NaN/missing per variant across all GT columns
-                        _gt_sub = gene_df[_gt_cols_list].fillna("./.").astype(str)
-                        _gt_norm = _gt_sub.apply(lambda col: col.str.replace("|", "/", regex=False))
-                        # A GT is missing if it contains "." as an allele
-                        _is_missing = _gt_norm.apply(
-                            lambda col: col.str.contains(r"(?:^|\/)\.(?:\/|$)", regex=True, na=True)
-                        )
-                        _miss_frac_per_variant = _is_missing.sum(axis=1) / _n_samples_gt
-                        _keep_mask_ann: np.ndarray | None = (
-                            _miss_frac_per_variant <= assoc_config.missing_site_threshold
-                        ).values
-                        # Only apply mask if some variants are filtered out
-                        if _keep_mask_ann is not None and bool(_keep_mask_ann.all()):
-                            _keep_mask_ann = None
-                    else:
-                        _keep_mask_ann = None
-
-                    if _cadd_col:
-                        _vals = gene_df[_cadd_col].values
-                        gene_data["cadd_scores"] = (
-                            _vals[_keep_mask_ann] if _keep_mask_ann is not None else _vals
-                        )
-                    if _revel_col:
-                        _vals = gene_df[_revel_col].values
-                        gene_data["revel_scores"] = (
-                            _vals[_keep_mask_ann] if _keep_mask_ann is not None else _vals
-                        )
-                    if _effect_col:
-                        _vals = gene_df[_effect_col].values
-                        gene_data["variant_effects"] = (
-                            _vals[_keep_mask_ann] if _keep_mask_ann is not None else _vals
-                        )
 
                 gene_data["vcf_samples"] = vcf_samples_list
 

--- a/variantcentrifuge/stages/analysis_stages.py
+++ b/variantcentrifuge/stages/analysis_stages.py
@@ -2084,6 +2084,7 @@ VALID_ASSOCIATION_KEYS: frozenset[str] = frozenset(
         "trait_type",
         "variant_weights",
         "variant_weight_params",
+        "variant_weight_column",
         "skat_backend",
         "skat_method",
         "coast_backend",
@@ -2145,6 +2146,7 @@ def _validate_association_config_dict(d: dict) -> None:
         "gene_burden_mode",
         "trait_type",
         "variant_weights",
+        "variant_weight_column",
         "skat_backend",
         "skat_method",
         "coast_backend",
@@ -2172,6 +2174,7 @@ def _validate_association_config_dict(d: dict) -> None:
     }
     list_str_keys = {"covariate_columns", "categorical_covariates", "association_tests"}
     list_float_keys = {"coast_weights"}
+    dict_keys = {"variant_weight_params"}
 
     for key in str_keys & set(d):
         if d[key] is not None and not isinstance(d[key], str):
@@ -2192,6 +2195,10 @@ def _validate_association_config_dict(d: dict) -> None:
     for key in list_float_keys & set(d):
         if d[key] is not None and not isinstance(d[key], list):
             errors.append(f"'{key}' must be a list, got {type(d[key]).__name__}")
+
+    for key in dict_keys & set(d):
+        if d[key] is not None and not isinstance(d[key], dict):
+            errors.append(f"'{key}' must be an object, got {type(d[key]).__name__}")
 
     # Enum-like value validation
     if "correction_method" in d and d["correction_method"] not in ("fdr", "bonferroni"):
@@ -2331,6 +2338,7 @@ def _build_assoc_config_from_context(context: "PipelineContext") -> AssociationC
         trait_type=_get("trait_type", default="binary", nullable=False),
         variant_weights=_get("variant_weights", default="beta:1,25", nullable=False),
         variant_weight_params=_get("variant_weight_params", default=None, nullable=True),
+        variant_weight_column=_get("variant_weight_column", default=None, nullable=True),
         missing_site_threshold=_get("missing_site_threshold", default=0.10, nullable=False),
         missing_sample_threshold=_get("missing_sample_threshold", default=0.80, nullable=False),
         firth_max_iter=_get("firth_max_iter", default=25, nullable=False),


### PR DESCRIPTION
## Summary

- Adds `score_column` variant weights to association configuration, CLI validation, weight resolution, and association-stage plumbing.
- Aligns score/CADD/REVEL/effect annotation arrays with the real genotype keep mask in lazy genotype construction.
- Passes explicit resolved weights into burden tests and the Python SKAT backend while preserving existing beta/uniform behavior.
- Rejects unsupported functional weights for the deprecated R SKAT backend with a clear error.
- Documents score-column association weighting and adds focused unit/integration coverage.

## Validation

- `pytest tests/unit -q` (`1742 passed, 58 warnings`)
- `python -m compileall variantcentrifuge`
- `git diff --check`

Closes #97.
