### PR TITLE
[codex] Fix NMD percent field parsing

### DIFF
--- a/tests/unit/test_bcftools_extractor.py
+++ b/tests/unit/test_bcftools_extractor.py
@@ -318,13 +318,31 @@ class TestNmdParsing:
 
     def test_parse_nmd_perc(self):
         """Test parsing NMD[0].PERC field."""
-        df = pd.DataFrame({"CHROM": ["chr1"], "POS": ["12345"], "NMD": ["0.95|other|fields"]})
+        df = pd.DataFrame(
+            {"CHROM": ["chr1"], "POS": ["12345"], "NMD": ["(ERMP1|ENSG00000099219|4|0.95)"]}
+        )
 
         fields = ["CHROM", "POS", "NMD[0].PERC"]
 
         result = parse_nmd_subfields(df, fields)
 
         assert "NMD" not in result.columns  # Raw NMD should be removed
+        assert result["NMD[0].PERC"].iloc[0] == "0.95"
+
+    def test_parse_nmd_perc_uses_first_annotation(self):
+        """Test parsing NMD[0].PERC from the first comma-separated NMD entry."""
+        df = pd.DataFrame(
+            {
+                "CHROM": ["chr1"],
+                "POS": ["12345"],
+                "NMD": ["(ERMP1|ENSG00000099219|4|0.95),(LRRC8A|ENSG00000150676|6|0.50)"],
+            }
+        )
+
+        fields = ["CHROM", "POS", "NMD[0].PERC"]
+
+        result = parse_nmd_subfields(df, fields)
+
         assert result["NMD[0].PERC"].iloc[0] == "0.95"
 
     def test_parse_missing_nmd(self):
@@ -335,9 +353,7 @@ class TestNmdParsing:
 
         result = parse_nmd_subfields(df, fields)
 
-        # When NMD is None, fillna("") creates empty string, split returns empty string
-        # This gets normalized to "NA" in the main extract function
-        assert result["NMD[0].PERC"].iloc[0] == ""  # Empty string before normalization
+        assert result["NMD[0].PERC"].iloc[0] == "NA"
 
     def test_no_nmd_column(self):
         """Test when NMD column is not present."""

--- a/variantcentrifuge/extractor.py
+++ b/variantcentrifuge/extractor.py
@@ -55,9 +55,13 @@ ANN_SUBFIELD_MAP = {
     "ANN[0].AA_LEN": ("AA.pos/AA.length", 13),  # Will need split
 }
 
-# NMD field positions (pipe-delimited, similar to ANN)
+# NMD field positions (pipe-delimited SnpEff LOF/NMD format:
+# Gene | ID | num_transcripts | percent_affected)
 NMD_SUBFIELD_MAP = {
-    "NMD[0].PERC": 0,  # First field is the percentage
+    "NMD[0].GENE": 0,
+    "NMD[0].GENEID": 1,
+    "NMD[0].NUMTR": 2,
+    "NMD[0].PERC": 3,
 }
 
 
@@ -257,8 +261,10 @@ def parse_nmd_subfields(df: pd.DataFrame, fields: list[str]) -> pd.DataFrame:
     if not nmd_fields_needed:
         return df.drop(columns=["NMD"])
 
-    # Take first NMD annotation
+    # Take first NMD annotation and remove SnpEff's surrounding parentheses:
+    # NMD=(GENE|GENEID|NUMTR|PERC)
     first_nmd = df["NMD"].fillna("").str.split(",", n=1).str[0]
+    first_nmd = first_nmd.str.strip().str.replace(r"^\((.*)\)$", r"\1", regex=True)
 
     # Split by pipe
     nmd_split = first_nmd.str.split("|", expand=True)


### PR DESCRIPTION
## Summary

- Fix bcftools NMD subfield parsing so `NMD[0].PERC` reads SnpEff percent_affected instead of the gene name.
- Strip SnpEff LOF/NMD parentheses before splitting pipe-delimited fields.
- Add regression coverage for real SnpEff-style single and comma-separated NMD annotations.

## Root cause

SnpEff LOF/NMD entries are `Gene | ID | num_transcripts | percent_affected`. The bcftools extraction path mapped `NMD[0].PERC` to pipe index 0, so gene symbols such as `ERMP1` and `LRRC8A` appeared in the percentage column.

## Validation

- `make format`
- `make lint`
- `make typecheck`
- `make format-check`
- `make ci-check` (`2178 passed, 3 skipped, 136 deselected, 58 warnings`)
