### PR TITLE
[codex] fix row-level snpeff burden filtering

### DIFF
--- a/docs/source/guides/association_testing.md
+++ b/docs/source/guides/association_testing.md
@@ -34,6 +34,32 @@ GENE2 312      488         3           0.41            1.23       0.74          
 **Primary significance measure:** `acat_o_qvalue` — this is the FDR-corrected omnibus
 p-value. Use it for all significance decisions.
 
+## Transcript-Selected Consequence Filtering
+
+When association or gene burden analysis uses a transcript list and consequence
+predicates from SnpEff, make the consequence filter row-level by splitting SnpEff
+annotations before SnpSift:
+
+```bash
+variantcentrifuge \
+  --gene-file genes.txt \
+  --vcf-file input.vcf.gz \
+  --transcript-file mane_select_transcripts.txt \
+  --preset high_or_lof_or_nmd \
+  --split-snpeff-lines before_filters \
+  --perform-association \
+  --output-file results.tsv
+```
+
+This matters for filters that inspect the whole annotation array, such as
+`ANN[ANY].IMPACT`, `LOF[*].PERC`, or `NMD[*].PERC`. In no-split mode, or with
+`--split-snpeff-lines after_filters`, SnpSift evaluates those predicates on the
+original multi-annotation VCF record before transcript selection. A record can
+therefore pass because one gene has a qualifying annotation while transcript
+filtering later retains a different gene. Use `before_filters` when the retained
+row itself must satisfy the consequence predicate before entering burden or
+association analysis.
+
 ---
 
 ## Setup: Covariates

--- a/docs/source/guides/custom_filters.md
+++ b/docs/source/guides/custom_filters.md
@@ -35,6 +35,15 @@ SnpSift uses a Java-like expression syntax:
 "((QUAL >= 30) & (AC[0] <= 5)) | (ClinVar_CLNSIG =~ '[Pp]athogenic')"
 ```
 
+:::{note}
+`ANN[ANY]`, `LOF[*]`, and `NMD[*]` are record-level predicates unless SnpEff
+annotations are split before SnpSift. For transcript-filtered gene burden or
+association analyses where the retained row itself must satisfy a consequence
+filter, use `--split-snpeff-lines before_filters`. The `after_filters` and
+no-split modes can still be useful, but they filter the original
+multi-annotation record before transcript selection.
+:::
+
 ## bcftools Pre-filter Syntax
 
 bcftools uses a different syntax optimized for speed:

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -107,7 +107,18 @@ flowchart TD
 | `--list-field-profiles` | — | List available field profiles and exit |
 | `--late-filtering` | `false` | Apply SnpSift filters after scoring (allows filtering on computed scores) |
 | `--final-filter EXPR` | — | Pandas `query()` expression applied after all annotations and scores |
-| `--split-snpeff-lines MODE` | — | Split multi-annotation lines: `before_filters` or `after_filters`. Omit to skip |
+| `--split-snpeff-lines MODE` | — | Split multi-annotation lines: `before_filters` or `after_filters`. Use `before_filters` for row-level ANN/LOF/NMD consequence filtering with transcript-selected gene burden or association. Omit to skip |
+
+:::{warning}
+When transcript filtering is combined with `--perform-gene-burden` or
+`--perform-association`, consequence filters such as `ANN[ANY]`, `LOF[*]`, and
+`NMD[*]` are row-level only when SnpEff annotations are split before SnpSift:
+`--split-snpeff-lines before_filters`. Without splitting, or with
+`after_filters`, SnpSift evaluates those predicates on the original VCF record
+before transcript selection. That can be useful for record-level filtering, but
+it is not the same as requiring the retained transcript row itself to satisfy
+the consequence predicate.
+:::
 
 ### Tumor-Normal Filtering
 

--- a/tests/integration/test_snpeff_row_level_burden.py
+++ b/tests/integration/test_snpeff_row_level_burden.py
@@ -1,0 +1,215 @@
+"""Regression coverage for SnpEff split rows used in burden/association inputs."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from variantcentrifuge.config import load_config
+from variantcentrifuge.extractor import extract_fields_bcftools
+from variantcentrifuge.filters import apply_snpsift_filter
+from variantcentrifuge.gene_burden import perform_gene_burden_analysis
+from variantcentrifuge.stages.processing_stages import ParallelCompleteProcessingStage
+from variantcentrifuge.transcript_filter import filter_vcf_to_transcripts
+from variantcentrifuge.vcf_eff_one_per_line import process_vcf_file as split_snpeff_annotations
+
+pytestmark = pytest.mark.skipif(
+    not all(shutil.which(tool) for tool in ("SnpSift", "bgzip", "bcftools", "tabix")),
+    reason="SnpSift, bgzip, bcftools, and tabix are required",
+)
+
+
+FIELDS_TO_EXTRACT = "CHROM POS ANN[0].GENE ANN[0].IMPACT NMD[0].PERC GEN[*].GT"
+VCF_SAMPLES = ["CASE", "CTRL"]
+
+
+def _high_or_lof_or_nmd_filter() -> str:
+    return load_config()["presets"]["high_or_lof_or_nmd"]
+
+
+def _issue_106_record(*, pos: int, positive_for_gene_b: bool) -> str:
+    if positive_for_gene_b:
+        info = (
+            "ANN="
+            "C|downstream_gene_variant|MODIFIER|GENE_A|ENSGA|transcript|NM_a|protein_coding||||||||,"
+            "C|missense_variant|MODERATE|GENE_B|ENSGB|transcript|NM_b|protein_coding||||||||;"
+            "NMD=(GENE_B|ENSGB|1|0.95)"
+        )
+        return f"chr1\t{pos}\t.\tG\tC\t500\tPASS\t{info}\tGT\t0/1\t0/0"
+
+    info = (
+        "ANN="
+        "T|splice_donor_variant|HIGH|GENE_A|ENSGA|transcript|NM_a|protein_coding||||||||,"
+        "T|downstream_gene_variant|MODIFIER|GENE_B|ENSGB|transcript|NM_b|protein_coding||||||||;"
+        "LOF=(GENE_A|ENSGA|1|0.95);"
+        "NMD=(GENE_A|ENSGA|1|0.91)"
+    )
+    return f"chr1\t{pos}\t.\tA\tT\t500\tPASS\t{info}\tGT\t0/1\t0/0"
+
+
+def _write_issue_106_vcf(
+    path: Path,
+    *,
+    include_negative: bool = True,
+    include_positive: bool = True,
+) -> None:
+    records = []
+    if include_negative:
+        records.append(_issue_106_record(pos=100, positive_for_gene_b=False))
+    if include_positive:
+        records.append(_issue_106_record(pos=200, positive_for_gene_b=True))
+
+    path.write_text(
+        "\n".join(
+            [
+                "##fileformat=VCFv4.2",
+                "##contig=<ID=chr1,length=1000>",
+                (
+                    '##INFO=<ID=ANN,Number=.,Type=String,Description="Functional '
+                    "annotations: Allele | Annotation | Annotation_Impact | Gene_Name | "
+                    "Gene_ID | Feature_Type | Feature_ID | Transcript_BioType | Rank | "
+                    "HGVS.c | HGVS.p | cDNA.pos / cDNA.length | CDS.pos / CDS.length | "
+                    'AA.pos / AA.length | Distance | ERRORS / WARNINGS / INFO">'
+                ),
+                (
+                    '##INFO=<ID=LOF,Number=.,Type=String,Description="Predicted loss of '
+                    'function effects">'
+                ),
+                (
+                    '##INFO=<ID=NMD,Number=.,Type=String,Description="Predicted nonsense '
+                    'mediated decay effects">'
+                ),
+                '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tCASE\tCTRL",
+                *records,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _read_tsv(path: Path) -> pd.DataFrame:
+    return pd.read_csv(path, sep="\t", dtype=str, keep_default_na=False)
+
+
+def _run_real_tool_flow(input_vcf: Path, tmp_path: Path) -> pd.DataFrame:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    split_vcf = tmp_path / "split.vcf.gz"
+    filtered_vcf = tmp_path / "filtered.vcf.gz"
+    transcript_vcf = tmp_path / "transcript_filtered.vcf.gz"
+    extracted_tsv = tmp_path / "extracted.tsv.gz"
+
+    split_snpeff_annotations(str(input_vcf), str(split_vcf))
+    apply_snpsift_filter(
+        str(split_vcf),
+        _high_or_lof_or_nmd_filter(),
+        {"threads": 1},
+        str(filtered_vcf),
+    )
+    filter_vcf_to_transcripts(str(filtered_vcf), str(transcript_vcf), {"NM_b"})
+    extract_fields_bcftools(
+        variant_file=str(transcript_vcf),
+        fields=FIELDS_TO_EXTRACT,
+        cfg={"extract_fields_separator": ","},
+        output_file=str(extracted_tsv),
+        vcf_samples=VCF_SAMPLES,
+    )
+
+    return _read_tsv(extracted_tsv)
+
+
+def _burden_input(df: pd.DataFrame) -> pd.DataFrame:
+    renamed = df.rename(columns={"ANN[0].GENE": "GENE"})
+    if "GENE" not in renamed.columns:
+        renamed["GENE"] = pd.Series(dtype=str)
+    return renamed
+
+
+def test_split_filter_transcript_flow_excludes_cross_gene_issue_106_row(tmp_path: Path) -> None:
+    input_vcf = tmp_path / "issue106.vcf"
+    _write_issue_106_vcf(input_vcf)
+
+    df = _run_real_tool_flow(input_vcf, tmp_path)
+
+    assert df["POS"].tolist() == ["200"]
+    assert df["ANN[0].GENE"].tolist() == ["GENE_B"]
+    assert df["ANN[0].IMPACT"].tolist() == ["MODERATE"]
+    assert df["NMD[0].PERC"].tolist() == ["0.95"]
+
+
+def test_parallel_chunk_worker_before_filters_excludes_cross_gene_issue_106_row(
+    tmp_path: Path,
+) -> None:
+    input_vcf = tmp_path / "issue106_negative.vcf"
+    indexed_vcf = tmp_path / "issue106_negative.vcf.gz"
+    chunk_bed = tmp_path / "chunk.bed"
+    intermediate_dir = tmp_path / "worker"
+    intermediate_dir.mkdir()
+
+    _write_issue_106_vcf(input_vcf, include_positive=False)
+    subprocess.run(["bcftools", "view", "-Oz", "-o", str(indexed_vcf), str(input_vcf)], check=True)
+    subprocess.run(["bcftools", "index", "-f", str(indexed_vcf)], check=True)
+    chunk_bed.write_text("chr1\t0\t150\n", encoding="utf-8")
+
+    chunk_tsv = ParallelCompleteProcessingStage()._process_single_chunk(
+        chunk_index=0,
+        chunk_bed=chunk_bed,
+        vcf_file=str(indexed_vcf),
+        base_name="issue106",
+        intermediate_dir=intermediate_dir,
+        config={
+            "threads_per_chunk": 1,
+            "snpeff_splitting_mode": "before_filters",
+            "filters": _high_or_lof_or_nmd_filter(),
+            "fields_to_extract": FIELDS_TO_EXTRACT,
+            "transcript_ids": {"NM_b"},
+            "vcf_samples": VCF_SAMPLES,
+            "gzip_intermediates": False,
+        },
+    )
+
+    df = _read_tsv(chunk_tsv)
+    assert df.empty
+    assert "CHROM" in df.columns
+
+
+def test_gene_burden_contract_uses_only_row_level_qualified_rows(tmp_path: Path) -> None:
+    negative_vcf = tmp_path / "negative.vcf"
+    positive_vcf = tmp_path / "positive.vcf"
+    _write_issue_106_vcf(negative_vcf, include_positive=False)
+    _write_issue_106_vcf(positive_vcf, include_negative=False)
+
+    negative_df = _burden_input(_run_real_tool_flow(negative_vcf, tmp_path / "negative_flow"))
+    positive_df = _burden_input(_run_real_tool_flow(positive_vcf, tmp_path / "positive_flow"))
+
+    assert "GENE_B" not in set(negative_df["GENE"])
+
+    burden_cfg = {
+        "gene_burden_mode": "samples",
+        "correction_method": "fdr",
+        "confidence_interval_method": "normal_approx",
+    }
+    negative_result = perform_gene_burden_analysis(
+        negative_df,
+        burden_cfg,
+        case_samples={"CASE"},
+        control_samples={"CTRL"},
+        vcf_samples=VCF_SAMPLES,
+    )
+    positive_result = perform_gene_burden_analysis(
+        positive_df,
+        burden_cfg,
+        case_samples={"CASE"},
+        control_samples={"CTRL"},
+        vcf_samples=VCF_SAMPLES,
+    )
+
+    assert negative_result.empty
+    assert positive_result["GENE"].tolist() == ["GENE_B"]
+    assert positive_result["proband_carrier_count"].tolist() == [1]
+    assert positive_result["control_carrier_count"].tolist() == [0]

--- a/tests/unit/stages/test_parallel_transcript_filter.py
+++ b/tests/unit/stages/test_parallel_transcript_filter.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from variantcentrifuge.stages.processing_stages import ParallelCompleteProcessingStage
 
 
@@ -72,3 +74,147 @@ def test_parallel_chunk_uses_preloaded_transcript_ids(
     mock_load_transcript_ids.assert_not_called()
     mock_filter_transcripts.assert_called_once()
     assert mock_filter_transcripts.call_args.args[2] == {"NM_parent_loaded.1"}
+
+
+@patch("variantcentrifuge.stages.processing_stages.extract_fields_bcftools")
+@patch("variantcentrifuge.stages.processing_stages.filter_vcf_to_transcripts")
+@patch("variantcentrifuge.stages.processing_stages.apply_snpsift_filter")
+@patch("variantcentrifuge.stages.processing_stages.split_snpeff_annotations")
+@patch("variantcentrifuge.stages.processing_stages.extract_variants")
+def test_parallel_chunk_splits_before_snpsift_when_requested(
+    mock_extract_variants,
+    mock_split,
+    mock_apply_filter,
+    mock_filter_transcripts,
+    mock_extract_fields,
+    tmp_path: Path,
+) -> None:
+    chunk_bed = tmp_path / "chunk.bed"
+    chunk_bed.write_text("1\t0\t100\n", encoding="utf-8")
+
+    stage = ParallelCompleteProcessingStage()
+    stage._process_single_chunk(
+        chunk_index=0,
+        chunk_bed=chunk_bed,
+        vcf_file="input.vcf.gz",
+        base_name="sample",
+        intermediate_dir=tmp_path,
+        config={
+            "threads_per_chunk": 1,
+            "snpeff_splitting_mode": "before_filters",
+            "filters": "(ANN[ANY].IMPACT has 'HIGH')",
+            "fields_to_extract": "CHROM POS ANN[0].GENE ANN[0].IMPACT GEN[*].GT",
+            "transcript_ids": {"NM_gene_b.1"},
+            "vcf_samples": ["S1"],
+        },
+    )
+
+    chunk_vcf = tmp_path / "sample.chunk_0.variants.vcf.gz"
+    split_vcf = tmp_path / "sample.chunk_0.split_annotations.vcf.gz"
+    filtered_vcf = tmp_path / "sample.chunk_0.filtered.vcf.gz"
+
+    mock_split.assert_called_once_with(str(chunk_vcf), str(split_vcf))
+    assert mock_apply_filter.call_args.args[0] == str(split_vcf)
+    assert mock_filter_transcripts.call_args.args[0] == str(filtered_vcf)
+    assert mock_extract_fields.call_args.kwargs["variant_file"] == str(
+        tmp_path / "sample.chunk_0.transcript_filtered.vcf.gz"
+    )
+
+
+@patch("variantcentrifuge.stages.processing_stages.extract_fields_bcftools")
+@patch("variantcentrifuge.stages.processing_stages.filter_vcf_to_transcripts")
+@patch("variantcentrifuge.stages.processing_stages.apply_snpsift_filter")
+@patch("variantcentrifuge.stages.processing_stages.split_snpeff_annotations")
+@patch("variantcentrifuge.stages.processing_stages.extract_variants")
+def test_parallel_chunk_splits_after_snpsift_when_requested(
+    mock_extract_variants,
+    mock_split,
+    mock_apply_filter,
+    mock_filter_transcripts,
+    mock_extract_fields,
+    tmp_path: Path,
+) -> None:
+    chunk_bed = tmp_path / "chunk.bed"
+    chunk_bed.write_text("1\t0\t100\n", encoding="utf-8")
+
+    stage = ParallelCompleteProcessingStage()
+    stage._process_single_chunk(
+        chunk_index=0,
+        chunk_bed=chunk_bed,
+        vcf_file="input.vcf.gz",
+        base_name="sample",
+        intermediate_dir=tmp_path,
+        config={
+            "threads_per_chunk": 1,
+            "snpeff_splitting_mode": "after_filters",
+            "filters": "(ANN[ANY].IMPACT has 'HIGH')",
+            "fields_to_extract": "CHROM POS ANN[0].GENE ANN[0].IMPACT GEN[*].GT",
+            "transcript_ids": {"NM_gene_b.1"},
+            "vcf_samples": ["S1"],
+        },
+    )
+
+    chunk_vcf = tmp_path / "sample.chunk_0.variants.vcf.gz"
+    filtered_vcf = tmp_path / "sample.chunk_0.filtered.vcf.gz"
+    split_vcf = tmp_path / "sample.chunk_0.split_annotations.vcf.gz"
+
+    assert mock_apply_filter.call_args.args[0] == str(chunk_vcf)
+    mock_split.assert_called_once_with(str(filtered_vcf), str(split_vcf))
+    assert mock_filter_transcripts.call_args.args[0] == str(split_vcf)
+    assert mock_extract_fields.call_args.kwargs["variant_file"] == str(
+        tmp_path / "sample.chunk_0.transcript_filtered.vcf.gz"
+    )
+
+
+@pytest.mark.parametrize(
+    "extra_config",
+    [
+        {"late_filtering": True, "filters": "(ANN[ANY].IMPACT has 'HIGH')"},
+        {},
+    ],
+)
+@patch("variantcentrifuge.stages.processing_stages.extract_fields_bcftools")
+@patch("variantcentrifuge.stages.processing_stages.filter_vcf_to_transcripts")
+@patch("variantcentrifuge.stages.processing_stages.apply_snpsift_filter")
+@patch("variantcentrifuge.stages.processing_stages.split_snpeff_annotations")
+@patch("variantcentrifuge.stages.processing_stages.extract_variants")
+def test_parallel_chunk_before_filter_fallbacks_preserve_split_working_vcf(
+    mock_extract_variants,
+    mock_split,
+    mock_apply_filter,
+    mock_filter_transcripts,
+    mock_extract_fields,
+    extra_config: dict[str, object],
+    tmp_path: Path,
+) -> None:
+    chunk_bed = tmp_path / "chunk.bed"
+    chunk_bed.write_text("1\t0\t100\n", encoding="utf-8")
+
+    config = {
+        "threads_per_chunk": 1,
+        "snpeff_splitting_mode": "before_filters",
+        "fields_to_extract": "CHROM POS ANN[0].GENE ANN[0].IMPACT GEN[*].GT",
+        "transcript_ids": {"NM_gene_b.1"},
+        "vcf_samples": ["S1"],
+    }
+    config.update(extra_config)
+
+    stage = ParallelCompleteProcessingStage()
+    stage._process_single_chunk(
+        chunk_index=0,
+        chunk_bed=chunk_bed,
+        vcf_file="input.vcf.gz",
+        base_name="sample",
+        intermediate_dir=tmp_path,
+        config=config,
+    )
+
+    chunk_vcf = tmp_path / "sample.chunk_0.variants.vcf.gz"
+    split_vcf = tmp_path / "sample.chunk_0.split_annotations.vcf.gz"
+
+    mock_split.assert_called_once_with(str(chunk_vcf), str(split_vcf))
+    mock_apply_filter.assert_not_called()
+    assert mock_filter_transcripts.call_args.args[0] == str(split_vcf)
+    assert mock_extract_fields.call_args.kwargs["variant_file"] == str(
+        tmp_path / "sample.chunk_0.transcript_filtered.vcf.gz"
+    )

--- a/tests/unit/stages/test_setup_stages.py
+++ b/tests/unit/stages/test_setup_stages.py
@@ -60,6 +60,41 @@ class TestConfigurationLoadingStage:
         stage = ConfigurationLoadingStage()
         assert stage.parallel_safe is True
 
+    def test_warns_for_transcript_analysis_consequence_filters_without_before_split(self, caplog):
+        """Warn when transcript-selected analysis would use record-level consequence filtering."""
+        context = create_test_context(
+            config={
+                "filters": "(ANN[ANY].IMPACT has 'HIGH')",
+                "transcript_file": "mane.txt",
+                "perform_gene_burden": True,
+                "snpeff_splitting_mode": "after_filters",
+            }
+        )
+
+        stage = ConfigurationLoadingStage()
+        with caplog.at_level("WARNING", logger="variantcentrifuge.stages.setup_stages"):
+            stage(context)
+
+        assert "--split-snpeff-lines before_filters" in caplog.text
+        assert "record before transcript selection" in caplog.text
+
+    def test_no_warning_for_before_split_transcript_analysis_consequence_filters(self, caplog):
+        """before_filters provides row-level consequence qualification."""
+        context = create_test_context(
+            config={
+                "filters": "(ANN[ANY].IMPACT has 'HIGH')",
+                "transcript_file": "mane.txt",
+                "perform_gene_burden": True,
+                "snpeff_splitting_mode": "before_filters",
+            }
+        )
+
+        stage = ConfigurationLoadingStage()
+        with caplog.at_level("WARNING", logger="variantcentrifuge.stages.setup_stages"):
+            stage(context)
+
+        assert "--split-snpeff-lines before_filters" not in caplog.text
+
 
 class TestPhenotypeLoadingStage:
     """Test PhenotypeLoadingStage."""

--- a/tests/unit/test_vcf_eff_one_per_line.py
+++ b/tests/unit/test_vcf_eff_one_per_line.py
@@ -1,0 +1,105 @@
+import logging
+
+from variantcentrifuge.vcf_eff_one_per_line import split_vcf_effects
+
+
+def _info_map(vcf_line: str) -> dict[str, str | None]:
+    info = vcf_line.split("\t")[7]
+    result: dict[str, str | None] = {}
+    for part in info.split(";"):
+        if "=" in part:
+            key, value = part.split("=", 1)
+            result[key] = value
+        else:
+            result[part] = None
+    return result
+
+
+def _split_rows_by_gene(vcf_line: str) -> dict[str, dict[str, str | None]]:
+    rows = split_vcf_effects(vcf_line)
+    by_gene = {}
+    for row in rows:
+        info = _info_map(row)
+        ann_parts = (info["ANN"] or "").split("|")
+        by_gene[ann_parts[3]] = info
+    return by_gene
+
+
+def test_split_ann_prunes_lof_nmd_to_matching_gene() -> None:
+    line = (
+        "chr1\t100\t.\tA\tT\t.\tPASS\t"
+        "AC=1;"
+        "ANN="
+        "T|splice_donor_variant|HIGH|GENE_A|ENSGA|transcript|NM_a|protein_coding||||||||,"
+        "T|downstream_gene_variant|MODIFIER|GENE_B|ENSGB|transcript|NM_b|protein_coding||||||||;"
+        "LOF=(GENE_A|ENSGA|1|0.95);"
+        "NMD=(GENE_A|ENSGA|1|0.91)"
+        "\tGT\t0/1"
+    )
+
+    rows_by_gene = _split_rows_by_gene(line)
+
+    assert rows_by_gene["GENE_A"]["LOF"] == "(GENE_A|ENSGA|1|0.95)"
+    assert rows_by_gene["GENE_A"]["NMD"] == "(GENE_A|ENSGA|1|0.91)"
+    assert "LOF" not in rows_by_gene["GENE_B"]
+    assert "NMD" not in rows_by_gene["GENE_B"]
+    assert rows_by_gene["GENE_A"]["AC"] == "1"
+    assert rows_by_gene["GENE_B"]["AC"] == "1"
+
+
+def test_split_ann_matches_lof_nmd_by_gene_id_when_symbol_differs() -> None:
+    line = (
+        "chr1\t100\t.\tA\tT\t.\tPASS\t"
+        "ANN="
+        "T|splice_donor_variant|HIGH|GENE_A|ENSGA|transcript|NM_a|protein_coding||||||||,"
+        "T|missense_variant|MODERATE|GENE_B_ALIAS|ENSGB|transcript|NM_b|protein_coding||||||||;"
+        "LOF=(GENE_B_CANONICAL|ENSGB|1|0.95);"
+        "NMD=(GENE_B_CANONICAL|ENSGB|1|0.91)"
+    )
+
+    rows_by_gene = _split_rows_by_gene(line)
+
+    assert "LOF" not in rows_by_gene["GENE_A"]
+    assert "NMD" not in rows_by_gene["GENE_A"]
+    assert rows_by_gene["GENE_B_ALIAS"]["LOF"] == "(GENE_B_CANONICAL|ENSGB|1|0.95)"
+    assert rows_by_gene["GENE_B_ALIAS"]["NMD"] == "(GENE_B_CANONICAL|ENSGB|1|0.91)"
+
+
+def test_split_ann_drops_malformed_lof_nmd_entries_and_warns(caplog) -> None:
+    line = (
+        "chr1\t100\t.\tA\tT\t.\tPASS\t"
+        "ANN="
+        "T|splice_donor_variant|HIGH|GENE_A|ENSGA|transcript|NM_a|protein_coding||||||||,"
+        "T|downstream_gene_variant|MODIFIER|GENE_B|ENSGB|transcript|NM_b|protein_coding||||||||;"
+        "LOF=(GENE_A|ENSGA|1|0.95),malformed;"
+        "NMD=also_malformed"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="variantcentrifuge.vcf_eff_one_per_line"):
+        rows_by_gene = _split_rows_by_gene(line)
+
+    assert rows_by_gene["GENE_A"]["LOF"] == "(GENE_A|ENSGA|1|0.95)"
+    assert "NMD" not in rows_by_gene["GENE_A"]
+    assert "LOF" not in rows_by_gene["GENE_B"]
+    assert "NMD" not in rows_by_gene["GENE_B"]
+    assert "Dropping malformed LOF entry" in caplog.text
+    assert "Dropping malformed NMD entry" in caplog.text
+
+
+def test_split_eff_preserves_lof_nmd_without_ann_pruning() -> None:
+    line = (
+        "chr1\t100\t.\tA\tT\t.\tPASS\t"
+        "AC=1;"
+        "EFF=STOP_GAINED(HIGH|MISSENSE|c.1A>T|p.Lys1*|1|GENE_A|protein_coding|CODING|NM_a|1),"
+        "DOWNSTREAM(MODIFIER|||||GENE_B|protein_coding|CODING|NM_b|1);"
+        "LOF=(GENE_A|ENSGA|1|0.95);"
+        "NMD=(GENE_A|ENSGA|1|0.91)"
+    )
+
+    rows = split_vcf_effects(line)
+
+    assert len(rows) == 2
+    for row in rows:
+        info = _info_map(row)
+        assert info["LOF"] == "(GENE_A|ENSGA|1|0.95)"
+        assert info["NMD"] == "(GENE_A|ENSGA|1|0.91)"

--- a/variantcentrifuge/cli.py
+++ b/variantcentrifuge/cli.py
@@ -277,9 +277,11 @@ def create_parser() -> argparse.ArgumentParser:
         help=(
             "If set, run the SNPeff annotation splitter step in one of two modes:\n"
             "  'before_filters' (default if no value is given) => Split lines right after variant extraction;\n"
-            "       recommended if you're also doing transcript filtering, though it can be slower.\n"
+            "       required for row-level ANN/LOF/NMD consequence qualification when combining\n"
+            "       transcript filtering with gene burden or association analysis.\n"
             "  'after_filters' => Only split EFF/ANN lines after the main filter step,\n"
-            "       produces a smaller intermediate file and can be faster for big multi-annotation VCFs.\n\n"
+            "       produces a smaller intermediate file and can be faster for big multi-annotation VCFs,\n"
+            "       but SnpSift consequence predicates are evaluated at record level.\n\n"
             "If omitted, splitting is not performed at all."
         ),
     )

--- a/variantcentrifuge/stages/processing_stages.py
+++ b/variantcentrifuge/stages/processing_stages.py
@@ -1196,24 +1196,35 @@ class ParallelCompleteProcessingStage(Stage):
         )
         extract_time = time.time() - extract_start
 
+        working_vcf = chunk_vcf
+        split_mode = config.get("snpeff_splitting_mode")
+        if split_mode == "before_filters":
+            split_vcf = intermediate_dir / f"{chunk_base}.split_annotations.vcf.gz"
+            split_snpeff_annotations(str(working_vcf), str(split_vcf))
+            working_vcf = split_vcf
+
         # Step 2: Apply SnpSift filter (if not late filtering)
         filter_start = time.time()
         if config.get("late_filtering", False):
-            filtered_vcf = chunk_vcf
+            filtered_vcf = working_vcf
             filter_time = 0.0
         else:
             filtered_vcf = intermediate_dir / f"{chunk_base}.filtered.vcf.gz"
             filter_expr = config.get("filter") or config.get("filters")
             if filter_expr:
                 apply_snpsift_filter(
-                    str(chunk_vcf),
+                    str(working_vcf),
                     filter_expr,
                     {"threads": config.get("threads_per_chunk", 2)},
                     str(filtered_vcf),
                 )
             else:
-                filtered_vcf = chunk_vcf
-            filter_time = time.time() - filter_start
+                filtered_vcf = working_vcf
+        if split_mode == "after_filters":
+            split_vcf = intermediate_dir / f"{chunk_base}.split_annotations.vcf.gz"
+            split_snpeff_annotations(str(filtered_vcf), str(split_vcf))
+            filtered_vcf = split_vcf
+        filter_time = time.time() - filter_start
 
         transcript_ids = config.get("transcript_ids")
         if transcript_ids is None:
@@ -1314,6 +1325,7 @@ class ParallelCompleteProcessingStage(Stage):
                 "threads_per_chunk": threads_per_worker,
                 "bcftools_prefilter": context.config.get("bcftools_prefilter"),
                 "late_filtering": context.config.get("late_filtering", False),
+                "snpeff_splitting_mode": context.config.get("snpeff_splitting_mode"),
                 "filter": context.config.get("filter"),
                 "filters": context.config.get("filters"),
                 "fields_to_extract": context.config.get("fields_to_extract", ""),

--- a/variantcentrifuge/stages/setup_stages.py
+++ b/variantcentrifuge/stages/setup_stages.py
@@ -17,6 +17,8 @@ from ..scoring import read_scoring_config
 
 logger = logging.getLogger(__name__)
 
+ROW_LEVEL_CONSEQUENCE_TOKENS = ("ANN[ANY]", "LOF[*]", "NMD[*]")
+
 
 def load_terms_from_file(file_path: str | None, logger: logging.Logger) -> list[str]:
     """
@@ -55,6 +57,34 @@ def load_terms_from_file(file_path: str | None, logger: logging.Logger) -> list[
                 logger.error(f"File {file_path} is empty or invalid.")
                 raise ValueError(f"File {file_path} is empty or invalid.")
     return terms
+
+
+def _warn_if_record_level_consequence_mode(config: dict) -> None:
+    """Warn when analysis options request row-level semantics from a record-level mode."""
+    if config.get("snpeff_splitting_mode") == "before_filters":
+        return
+
+    transcript_filtering_requested = bool(
+        config.get("transcript_list")
+        or config.get("transcript_file")
+        or config.get("transcript_ids")
+    )
+    analysis_requested = bool(
+        config.get("perform_gene_burden") or config.get("perform_association")
+    )
+    filter_expr = config.get("filter") or config.get("filters") or ""
+    consequence_filter_requested = isinstance(filter_expr, str) and any(
+        token in filter_expr for token in ROW_LEVEL_CONSEQUENCE_TOKENS
+    )
+
+    if transcript_filtering_requested and analysis_requested and consequence_filter_requested:
+        logger.warning(
+            "Transcript-filtered gene burden/association with ANN[ANY], LOF[*], or "
+            "NMD[*] consequence predicates should use --split-snpeff-lines before_filters "
+            "for row-level consequence qualification. Without before_filters, SnpSift "
+            "evaluates those predicates on the original multi-annotation record before "
+            "transcript selection."
+        )
 
 
 class ConfigurationLoadingStage(Stage):
@@ -201,6 +231,8 @@ class ConfigurationLoadingStage(Stage):
         # Update config with parsed lists
         config["case_samples"] = case_samples
         config["control_samples"] = control_samples
+
+        _warn_if_record_level_consequence_mode(config)
 
         # Update context
         context.config = config

--- a/variantcentrifuge/vcf_eff_one_per_line.py
+++ b/variantcentrifuge/vcf_eff_one_per_line.py
@@ -44,9 +44,43 @@ Command-line arguments:
 import argparse
 import gzip
 import io
+import logging
 import re
 import subprocess
 import sys
+
+logger = logging.getLogger(__name__)
+
+ANN_GENE_NAME_INDEX = 3
+ANN_GENE_ID_INDEX = 4
+
+
+def _ann_gene_keys(ann_entry: str) -> set[str]:
+    """Return non-empty gene name and gene ID keys from a SnpEff ANN entry."""
+    parts = ann_entry.split("|")
+    gene_keys = set()
+    if len(parts) > ANN_GENE_NAME_INDEX and parts[ANN_GENE_NAME_INDEX]:
+        gene_keys.add(parts[ANN_GENE_NAME_INDEX])
+    if len(parts) > ANN_GENE_ID_INDEX and parts[ANN_GENE_ID_INDEX]:
+        gene_keys.add(parts[ANN_GENE_ID_INDEX])
+    return gene_keys
+
+
+def _filter_gene_scoped_info_value(value: str, gene_keys: set[str], info_key: str) -> str | None:
+    """Keep LOF/NMD entries whose gene symbol or ID matches the retained ANN gene."""
+    kept_entries = []
+    for entry in value.split(","):
+        stripped = entry.strip()
+        parts = stripped.strip("()").split("|")
+        if len(parts) < 2:
+            logger.warning("Dropping malformed %s entry from ANN split row: %s", info_key, entry)
+            continue
+        if parts[0] in gene_keys or parts[1] in gene_keys:
+            kept_entries.append(entry)
+
+    if not kept_entries:
+        return None
+    return ",".join(kept_entries)
 
 
 def split_vcf_effects(line: str) -> list[str]:
@@ -78,16 +112,20 @@ def split_vcf_effects(line: str) -> list[str]:
     effs: list[str] = []
     field_name = None
     other_info_parts = []
+    gene_scoped_info_parts: list[tuple[str, str]] = []
 
     for inf in infos:
         match_eff = re.match(r"^(EFF)=(.*)", inf)
         match_ann = re.match(r"^(ANN)=(.*)", inf)
+        match_gene_scoped = re.match(r"^(LOF|NMD)=(.*)", inf)
         if match_eff:
             field_name = match_eff.group(1)
             effs = match_eff.group(2).split(",")
         elif match_ann:
             field_name = match_ann.group(1)
             effs = match_ann.group(2).split(",")
+        elif match_gene_scoped:
+            gene_scoped_info_parts.append((match_gene_scoped.group(1), match_gene_scoped.group(2)))
         else:
             other_info_parts.append(inf)
 
@@ -106,11 +144,21 @@ def split_vcf_effects(line: str) -> list[str]:
     # Reconstruct lines with each effect/annotation on separate lines
     for eff in effs:
         # Build the final INFO field: combine leftover info with the single EFF/ANN
-        new_info = ";".join(filter(None, other_info_parts))
-        if new_info:
-            new_info += f";{field_name}={eff}"
+        new_info_parts = list(filter(None, other_info_parts))
+        if field_name == "ANN":
+            new_info_parts.append(f"{field_name}={eff}")
+            gene_keys = _ann_gene_keys(eff)
+            for info_key, value in gene_scoped_info_parts:
+                filtered_value = _filter_gene_scoped_info_value(value, gene_keys, info_key)
+                if filtered_value is not None:
+                    new_info_parts.append(f"{info_key}={filtered_value}")
         else:
-            new_info = f"{field_name}={eff}"
+            new_info_parts.extend(
+                f"{info_key}={value}" for info_key, value in gene_scoped_info_parts
+            )
+            new_info_parts.append(f"{field_name}={eff}")
+
+        new_info = ";".join(new_info_parts)
 
         new_line = f"{pre_string}\t{new_info}{post_string}"
         split_lines.append(new_line)


### PR DESCRIPTION
## Summary
- honor SnpEff split mode in parallel chunk processing, including before/after SnpSift ordering and late/no-filter fallback paths
- prune LOF/NMD provenance on ANN split rows so retained rows only carry gene-matched LOF/NMD entries; legacy EFF rows are unchanged
- add issue #106 unit and real-tool regressions, plus a startup warning and docs for transcript-filtered burden/association without before_filters

## Root Cause
Parallel chunk workers did not receive or apply snpeff_splitting_mode, so before_filters runs could still evaluate SnpSift against unsplit records. The ANN splitter also copied LOF/NMD INFO values to every split row, allowing another gene's LOF/NMD evidence to qualify a retained transcript row.

## Validation
- pytest tests/unit/stages/test_setup_stages.py::TestConfigurationLoadingStage -q
- pytest tests/unit/test_vcf_eff_one_per_line.py tests/unit/test_transcript_filter.py tests/unit/stages/test_parallel_transcript_filter.py tests/unit/stages/test_processing_stages_critical.py tests/integration/test_snpeff_row_level_burden.py -q
- pytest tests/test_gene_burden.py tests/unit/test_association_stage.py -q
- pytest tests/unit/test_filters.py tests/integration/test_snpsift_filter_guards.py -q