### PR TITLE
Fix Fisher-only weighted FDR column names

### DIFF
--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -304,11 +304,11 @@ variantcentrifuge \
 
 The covariate file should be a TSV or CSV with sample IDs in the first column and covariate values in subsequent columns (header required). Logistic burden regression fits a weighted burden score as the predictor with covariates, reporting beta coefficients and standard errors. For quantitative traits, use `--trait-type quantitative` with `--association-tests linear_burden`. See the [Association Testing Guide](guides/association_testing.md) for full details.
 
-### What is ACAT-O and why should I use `acat_o_qvalue`?
+### What is ACAT-O and when should I use `acat_o_qvalue`?
 
 ACAT-O (Aggregated Cauchy Association Test — Omnibus) combines p-values from multiple association tests per gene into a single omnibus p-value using the Cauchy combination method (Liu and Xie, 2020). It is robust to the unknown correlation between tests and does not require simulation.
 
-When you run multiple tests (e.g., `--association-tests fisher,logistic_burden,skat`), each test may capture different genetic architectures: Fisher detects dominant carrier effects, burden tests detect directional cumulative effects, and SKAT-O detects heterogeneous effects without sign constraints. ACAT-O combines evidence from all active tests into a single per-gene p-value. A single Benjamini-Hochberg FDR correction is applied to `acat_o_pvalue` across all genes to produce `acat_o_qvalue`. This is the primary significance measure to report; individual test p-values serve for diagnostic signal decomposition only. See the [Association Testing Guide](guides/association_testing.md) for the test selection reference table.
+When you run multiple tests (e.g., `--association-tests fisher,logistic_burden,skat`), each test may capture different genetic architectures: Fisher detects dominant carrier effects, burden tests detect directional cumulative effects, and SKAT-O detects heterogeneous effects without sign constraints. ACAT-O combines evidence from all active tests into a single per-gene p-value. A single Benjamini-Hochberg FDR correction is applied to the primary p-value across all genes. For multi-test runs, `acat_o_qvalue` is the primary corrected result; for single-test runs such as Fisher-only, use `primary_qvalue` or the test-specific column such as `fisher_qvalue`. See the [Association Testing Guide](guides/association_testing.md) for the test selection reference table.
 
 ### Do I need R installed for SKAT or COAST?
 

--- a/docs/source/guides/association_testing.md
+++ b/docs/source/guides/association_testing.md
@@ -25,14 +25,15 @@ variantcentrifuge \
 Output: `results.association.tsv` with columns:
 
 ```
-gene  n_cases  n_controls  n_variants  fisher_pvalue  fisher_or  fisher_or_ci_lower  fisher_or_ci_upper  acat_o_pvalue  acat_o_qvalue  warnings
-GENE1 312      488         7           0.00031         3.82       1.87                7.78                0.00031         0.0047
-GENE2 312      488         3           0.41            1.23       0.74                2.05                0.41            1.0
+gene  n_cases  n_controls  n_variants  fisher_pvalue  fisher_qvalue  fisher_or  fisher_or_ci_lower  fisher_or_ci_upper  primary_test  primary_pvalue  primary_qvalue  warnings
+GENE1 312      488         7           0.00031         0.0047         3.82       1.87                7.78                fisher        0.00031         0.0047
+GENE2 312      488         3           0.41            1.0            1.23       0.74                2.05                fisher        0.41            1.0
 ...
 ```
 
-**Primary significance measure:** `acat_o_qvalue` — this is the FDR-corrected omnibus
-p-value. Use it for all significance decisions.
+**Primary significance measure:** `primary_qvalue`. For Fisher-only runs this is the same
+value as `fisher_qvalue`; for multi-test runs it is usually the same value as
+`acat_o_qvalue`.
 
 ## Transcript-Selected Consequence Filtering
 
@@ -456,32 +457,39 @@ correlation between test statistics.
 
 **References:** Liu et al. 2019 AJHG; Liu and Xie 2020 JASA.
 
-ACAT-O is **not** a test you activate separately — it is computed automatically after all
-selected tests have run. When SKAT is active, ACAT-V is also included in the combination.
+ACAT-O is **not** a test you activate separately — it is computed automatically after
+multiple selected tests have run. When SKAT is active, ACAT-V is also included in the
+combination.
 
 ### FDR Correction Strategy
 
-A **single** Benjamini-Hochberg FDR correction pass is applied to the ACAT-O p-values across all
-genes. Individual test p-values (`fisher_pvalue`, `skat_o_pvalue`, etc.) are **not** corrected.
+A **single** Benjamini-Hochberg FDR correction pass is applied to the primary p-values across
+all genes. In multi-test and SKAT runs, the primary p-value is ACAT-O. In single-test runs
+such as Fisher-only, the primary p-value is that test's own p-value, and the corrected value is
+also exposed under a test-specific column such as `fisher_qvalue`.
 
 :::{warning}
-Do not apply additional correction to individual test p-values, and do not apply FDR separately
-per test. Both approaches are statistically incorrect given this design. Use
-`acat_o_qvalue` as your primary significance measure.
+Do not apply additional correction to the output p-values, and do not apply FDR separately per
+test. Both approaches are statistically incorrect given this design. Use `primary_qvalue` as
+your primary significance measure.
 :::
 
 ### Output Columns
 
 | Column | Description |
 |--------|-------------|
-| `acat_o_pvalue` | Raw (uncorrected) ACAT-O omnibus p-value |
-| `acat_o_qvalue` | FDR-corrected (Benjamini-Hochberg) ACAT-O p-value |
+| `primary_test` | Name of the result used for correction (`fisher`, `acat_o`, etc.) |
+| `primary_pvalue` | Raw p-value used for the single correction pass |
+| `primary_qvalue` | Corrected primary p-value; use this for significance decisions |
+| `<test>_qvalue` | Corrected p-value for a single-test run, e.g. `fisher_qvalue` |
+| `acat_o_pvalue` | Raw ACAT-O omnibus p-value; present when ACAT-O is the primary result |
+| `acat_o_qvalue` | Corrected ACAT-O p-value; present when ACAT-O is the primary result |
 
 ### Pass-Through Behaviour
 
-When only one test is active, `acat_o_pvalue` equals that test's raw p-value (pass-through).
-FDR correction is still applied across genes. This is by design — the omnibus is always a safe
-primary measure.
+For single-test runs without a real omnibus combination, VariantCentrifuge no longer writes
+ACAT-O pass-through columns. For example, Fisher-only output uses `fisher_pvalue`,
+`fisher_qvalue`, and the generic `primary_*` columns.
 
 ---
 
@@ -795,6 +803,9 @@ file is written:
 
 The `significance_change` column highlights genes where weighting changed the significance
 call at FDR < 0.05. This is the primary way to assess the impact of your weight choices.
+When weighted FDR is active, the main association output also includes explicit weighted and
+unweighted aliases for the primary result, such as `fisher_weighted_qvalue`,
+`fisher_unweighted_qvalue`, `primary_weighted_qvalue`, and `primary_unweighted_qvalue`.
 
 ### Coverage Warnings
 
@@ -1060,12 +1071,14 @@ head vcf_samples.txt
 
 Ensure the first column of `covariates.tsv` matches these names exactly.
 
-### ACAT-O Equals Single Test P-value
+### Missing ACAT-O Columns In Fisher-Only Output
 
-**What you see:** `acat_o_pvalue` is identical to `fisher_pvalue` for all genes.
+**What you see:** Fisher-only output contains `fisher_qvalue` and `primary_qvalue`, but no
+`acat_o_pvalue` or `acat_o_qvalue`.
 
-**This is correct behavior.** When only one test is active, the Cauchy combination of a single
-p-value returns that p-value unchanged (pass-through). FDR correction still runs across genes.
+**This is correct behavior.** ACAT-O columns are written only when ACAT-O is the primary result.
+For Fisher-only runs, the corrected value is the Fisher result, so it is written as
+`fisher_qvalue` and mirrored in `primary_qvalue`.
 
 To get a true omnibus combination, enable multiple tests:
 ```bash
@@ -1074,9 +1087,10 @@ To get a true omnibus combination, enable multiple tests:
 
 ### Missing ACAT-O Columns
 
-ACAT-O columns are always present in the output when `--perform-association` is active. If you
-do not see them, check that the output file is `results.association.tsv` (not `results.tsv`
-itself — the association results go to a separate `.association.tsv` file).
+ACAT-O columns are present for multi-test and SKAT runs. If you expect them but do not see
+them, first check that the output file is `results.association.tsv` (not `results.tsv` itself
+— the association results go to a separate `.association.tsv` file), then check the selected
+tests in `--association-tests`.
 
 ---
 

--- a/tests/unit/test_association_engine.py
+++ b/tests/unit/test_association_engine.py
@@ -7,6 +7,7 @@ output schema, zero-variant gene skipping, and correction application.
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 from variantcentrifuge.association.base import AssociationConfig
@@ -124,9 +125,8 @@ class TestAssociationEngineRunAll:
     def test_run_all_output_columns(self, default_config):
         """run_all output contains all expected columns.
 
-        ARCH-03: Primary tests no longer have corrected_p_value columns.
-        FDR is applied only to ACAT-O, which appears as acat_o_pvalue and
-        acat_o_qvalue.
+        Fisher-only correction is exposed with Fisher-specific and generic
+        primary columns, not ACAT-O pass-through columns.
         """
         gene_data = [
             _make_gene_data(
@@ -142,16 +142,18 @@ class TestAssociationEngineRunAll:
             "n_controls",
             "n_variants",
             "fisher_pvalue",
-            # ARCH-03: no fisher_corrected_pvalue — FDR applied to ACAT-O only
-            "acat_o_pvalue",
-            "acat_o_qvalue",
+            "fisher_qvalue",
             "fisher_or",
             "fisher_or_ci_lower",
             "fisher_or_ci_upper",
+            "primary_test",
+            "primary_pvalue",
+            "primary_qvalue",
         }
         assert expected_cols.issubset(set(result.columns))
-        # Primary test must NOT have a corrected_p_value column (ARCH-03)
         assert "fisher_corrected_pvalue" not in result.columns
+        assert "acat_o_pvalue" not in result.columns
+        assert "acat_o_qvalue" not in result.columns
 
     def test_run_all_multiple_genes_returns_sorted(self, default_config):
         """run_all with multiple genes returns them sorted alphabetically by gene."""
@@ -210,12 +212,7 @@ class TestAssociationEngineRunAll:
         assert result.empty
 
     def test_run_all_corrected_p_values_populated(self, default_config):
-        """run_all populates ACAT-O corrected p-values for all genes.
-
-        ARCH-03: FDR is applied only to ACAT-O p-values (not per-test).
-        Primary test p-values (fisher_pvalue) are raw/uncorrected.
-        acat_o_qvalue is populated after correction.
-        """
+        """run_all populates Fisher-specific and primary q-values for Fisher-only runs."""
         gene_data = [
             _make_gene_data(
                 "BRCA1", p_carriers=5, c_carriers=1, p_total=100, c_total=200, n_variants=3
@@ -227,11 +224,11 @@ class TestAssociationEngineRunAll:
         engine = AssociationEngine.from_names(["fisher"], default_config)
         result = engine.run_all(gene_data)
 
-        # ACAT-O corrected p-values must be non-None (correction was applied)
-        assert result["acat_o_qvalue"].notna().all()
-        # Primary test p-values are raw (no per-test FDR per ARCH-03)
+        assert result["fisher_qvalue"].notna().all()
+        assert result["primary_qvalue"].notna().all()
+        np.testing.assert_allclose(result["fisher_qvalue"], result["primary_qvalue"])
         assert "fisher_corrected_pvalue" not in result.columns
-        # Fisher raw p-values are present
+        assert "acat_o_qvalue" not in result.columns
         assert result["fisher_pvalue"].notna().all()
 
     def test_run_all_sort_order_reverse_input_still_alphabetical(self, default_config):
@@ -350,24 +347,16 @@ class TestAssociationEngineColumnNaming:
 
 
 # ---------------------------------------------------------------------------
-# ACAT-O integration tests (Phase 22 / ARCH-03)
+# Primary correction output tests
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-class TestAssociationEngineAcatO:
-    """Tests for ACAT-O omnibus column presence and FDR strategy (ARCH-03).
+class TestAssociationEnginePrimaryOutput:
+    """Tests for primary p/q-value output naming."""
 
-    These tests verify that:
-    1. acat_o_pvalue and acat_o_qvalue columns are always present
-    2. Primary test corrected_p_value columns are never present (ARCH-03)
-    3. Single-test pass-through: acat_o_pvalue == fisher_pvalue when k=1
-    4. FDR is applied only to ACAT-O (corrected p-values populated for valid genes)
-    5. Zero-variant genes have acat_o_pvalue=None
-    """
-
-    def test_engine_acat_o_columns_present(self, default_config):
-        """run_all with fisher test produces acat_o_pvalue and acat_o_qvalue columns."""
+    def test_engine_fisher_only_uses_fisher_qvalue_not_acat_o(self, default_config):
+        """Fisher-only output does not expose corrected values as ACAT-O."""
         gene_data = [
             _make_gene_data(
                 "BRCA1", p_carriers=5, c_carriers=1, p_total=100, c_total=200, n_variants=3
@@ -376,15 +365,14 @@ class TestAssociationEngineAcatO:
         engine = AssociationEngine.from_names(["fisher"], default_config)
         result = engine.run_all(gene_data)
 
-        assert "acat_o_pvalue" in result.columns, "acat_o_pvalue column missing from output"
-        assert "acat_o_qvalue" in result.columns, "acat_o_qvalue column missing from output"
+        assert "fisher_qvalue" in result.columns
+        assert "primary_pvalue" in result.columns
+        assert "primary_qvalue" in result.columns
+        assert "acat_o_pvalue" not in result.columns
+        assert "acat_o_qvalue" not in result.columns
 
-    def test_engine_acat_o_single_test_passthrough(self, default_config):
-        """With only fisher test, acat_o_pvalue equals fisher_pvalue (k=1 pass-through).
-
-        IMPL-35: Single valid p-value passes through cauchy_combination unchanged.
-        When there is only one primary test, ACAT-O is identical to that test's p-value.
-        """
+    def test_engine_fisher_only_primary_pvalue_matches_fisher(self, default_config):
+        """With only Fisher active, primary_pvalue is the Fisher p-value."""
         import pytest
 
         gene_data = [
@@ -396,19 +384,15 @@ class TestAssociationEngineAcatO:
         result = engine.run_all(gene_data)
 
         row = result.iloc[0]
-        assert row["acat_o_pvalue"] is not None
+        assert row["primary_pvalue"] is not None
         assert row["fisher_pvalue"] is not None
-        assert row["acat_o_pvalue"] == pytest.approx(row["fisher_pvalue"], rel=1e-9), (
-            "With k=1 test, acat_o_pvalue should equal fisher_pvalue (pass-through)"
+        assert row["primary_test"] == "fisher"
+        assert row["primary_pvalue"] == pytest.approx(row["fisher_pvalue"], rel=1e-9), (
+            "With only Fisher active, primary_pvalue should equal fisher_pvalue"
         )
 
-    def test_engine_acat_o_fdr_applied(self, default_config):
-        """acat_o_qvalue is not None for genes with valid ACAT-O p-values.
-
-        ARCH-03: FDR is applied to ACAT-O across all genes. After correction,
-        acat_o_qvalue should be populated for every gene that had a
-        valid acat_o_pvalue.
-        """
+    def test_engine_fisher_only_fdr_applied(self, default_config):
+        """fisher_qvalue is populated for genes with valid Fisher p-values."""
         gene_data = [
             _make_gene_data(
                 "BRCA1", p_carriers=5, c_carriers=1, p_total=100, c_total=200, n_variants=3
@@ -423,19 +407,67 @@ class TestAssociationEngineAcatO:
         engine = AssociationEngine.from_names(["fisher"], default_config)
         result = engine.run_all(gene_data)
 
-        # All genes that have acat_o_pvalue should also have acat_o_qvalue
-        genes_with_acat_p = result[result["acat_o_pvalue"].notna()]
-        assert len(genes_with_acat_p) > 0, "No genes had valid acat_o_pvalue"
-        assert genes_with_acat_p["acat_o_qvalue"].notna().all(), (
-            "Some genes with valid acat_o_pvalue have None acat_o_qvalue"
+        genes_with_fisher_p = result[result["fisher_pvalue"].notna()]
+        assert len(genes_with_fisher_p) > 0, "No genes had valid fisher_pvalue"
+        assert genes_with_fisher_p["fisher_qvalue"].notna().all()
+        np.testing.assert_allclose(
+            genes_with_fisher_p["fisher_qvalue"],
+            genes_with_fisher_p["primary_qvalue"],
         )
 
-    def test_engine_primary_tests_no_fdr(self, default_config):
-        """Primary test corrected_p_value columns are absent (ARCH-03).
+    def test_engine_fisher_only_weighted_fdr_uses_fisher_named_columns(self, tmp_path):
+        """Regression test for issue #108: weighted Fisher FDR is not named ACAT-O."""
+        import pandas as pd
 
-        FDR is applied only to ACAT-O. Primary test raw p-values exist for
-        diagnostic signal decomposition, but they are NOT independently corrected.
-        """
+        weight_file = tmp_path / "weights.tsv"
+        weight_file.write_text("gene\tweight\nBRCA1\t3.0\nMYH7\t1.0\nTP53\t0.5\n")
+        diagnostics_dir = tmp_path / "diagnostics"
+
+        config = AssociationConfig(
+            correction_method="fdr",
+            gene_burden_mode="samples",
+            gene_prior_weights=str(weight_file),
+            diagnostics_output=str(diagnostics_dir),
+        )
+        gene_data = [
+            _make_gene_data(
+                "TP53", p_carriers=3, c_carriers=0, p_total=100, c_total=200, n_variants=2
+            ),
+            _make_gene_data(
+                "BRCA1", p_carriers=5, c_carriers=1, p_total=100, c_total=200, n_variants=3
+            ),
+            _make_gene_data(
+                "MYH7", p_carriers=8, c_carriers=2, p_total=100, c_total=200, n_variants=5
+            ),
+        ]
+
+        result = AssociationEngine.from_names(["fisher"], config).run_all(gene_data)
+
+        assert "fisher_qvalue" in result.columns
+        assert "fisher_weighted_qvalue" in result.columns
+        assert "fisher_unweighted_qvalue" in result.columns
+        assert "primary_qvalue" in result.columns
+        assert "primary_weighted_qvalue" in result.columns
+        assert "primary_unweighted_qvalue" in result.columns
+        assert "fdr_weight" in result.columns
+        assert "acat_o_pvalue" not in result.columns
+        assert "acat_o_qvalue" not in result.columns
+
+        np.testing.assert_allclose(result["primary_pvalue"], result["fisher_pvalue"])
+        np.testing.assert_allclose(result["primary_qvalue"], result["fisher_qvalue"])
+        np.testing.assert_allclose(result["fisher_qvalue"], result["fisher_weighted_qvalue"])
+        np.testing.assert_allclose(
+            result["primary_weighted_qvalue"],
+            result["fisher_weighted_qvalue"],
+        )
+
+        diagnostics = pd.read_csv(diagnostics_dir / "fdr_weight_diagnostics.tsv", sep="\t")
+        merged = result.merge(diagnostics[["gene", "weighted_q", "unweighted_q"]], on="gene")
+        np.testing.assert_allclose(merged["fisher_weighted_qvalue"], merged["weighted_q"])
+        np.testing.assert_allclose(merged["fisher_unweighted_qvalue"], merged["unweighted_q"])
+
+    def test_engine_primary_tests_no_fdr(self, default_config):
+        """Legacy corrected_pvalue column spelling remains absent."""
         gene_data = [
             _make_gene_data(
                 "BRCA1", p_carriers=5, c_carriers=1, p_total=100, c_total=200, n_variants=3
@@ -447,13 +479,13 @@ class TestAssociationEngineAcatO:
         engine = AssociationEngine.from_names(["fisher"], default_config)
         result = engine.run_all(gene_data)
 
-        # Fisher must not have a corrected p-value column (ARCH-03)
+        # Fisher q-values are exposed as fisher_qvalue, not a legacy corrected_pvalue column.
         assert "fisher_corrected_pvalue" not in result.columns, (
-            "ARCH-03 violated: fisher_corrected_pvalue should not be in output columns"
+            "fisher_corrected_pvalue should not be in output columns"
         )
 
-    def test_engine_acat_o_none_for_zero_variant_gene(self, default_config):
-        """Gene with 0 variants is excluded from results; no row means no acat_o_pvalue.
+    def test_engine_primary_none_for_zero_variant_gene(self, default_config):
+        """Gene with 0 variants is excluded from results; no row means no primary p-value.
 
         IMPL-02: p_value=None for zero-variant genes (not 1.0). These genes are
         skipped in the engine output entirely (not included as rows with None values).
@@ -476,11 +508,10 @@ class TestAssociationEngineAcatO:
         # Only BRCA1 should be present
         assert len(result) == 1
         assert result.iloc[0]["gene"] == "BRCA1"
-        # BRCA1 has valid acat_o_pvalue
-        assert result.iloc[0]["acat_o_pvalue"] is not None
+        assert result.iloc[0]["primary_pvalue"] is not None
 
-    def test_engine_acat_o_corrected_p_in_range(self, default_config):
-        """acat_o_qvalue values are in [0, 1]."""
+    def test_engine_primary_corrected_p_in_range(self, default_config):
+        """primary_qvalue values are in [0, 1]."""
         gene_data = [
             _make_gene_data(
                 "BRCA1", p_carriers=5, c_carriers=1, p_total=100, c_total=200, n_variants=3
@@ -492,11 +523,11 @@ class TestAssociationEngineAcatO:
         engine = AssociationEngine.from_names(["fisher"], default_config)
         result = engine.run_all(gene_data)
 
-        for val in result["acat_o_qvalue"].dropna():
-            assert 0.0 <= val <= 1.0, f"acat_o_qvalue {val} outside [0, 1]"
+        for val in result["primary_qvalue"].dropna():
+            assert 0.0 <= val <= 1.0, f"primary_qvalue {val} outside [0, 1]"
 
-    def test_engine_acat_o_raw_p_in_range(self, default_config):
-        """acat_o_pvalue raw p-values are in [0, 1]."""
+    def test_engine_primary_raw_p_in_range(self, default_config):
+        """primary_pvalue raw p-values are in [0, 1]."""
         gene_data = [
             _make_gene_data(
                 "BRCA1", p_carriers=5, c_carriers=1, p_total=100, c_total=200, n_variants=3
@@ -505,5 +536,5 @@ class TestAssociationEngineAcatO:
         engine = AssociationEngine.from_names(["fisher"], default_config)
         result = engine.run_all(gene_data)
 
-        for val in result["acat_o_pvalue"].dropna():
-            assert 0.0 <= val <= 1.0, f"acat_o_pvalue {val} outside [0, 1]"
+        for val in result["primary_pvalue"].dropna():
+            assert 0.0 <= val <= 1.0, f"primary_pvalue {val} outside [0, 1]"

--- a/tests/unit/test_association_fisher.py
+++ b/tests/unit/test_association_fisher.py
@@ -205,12 +205,7 @@ class TestFisherBitIdentitySamplesMode:
             assert row["fisher_or"] == expected_or, f"OR mismatch for {gene_name}"
 
     def test_bit_identity_corrected_p_values_match_direct_smm(self):
-        """ACAT-O corrected p-values match direct smm.multipletests on ACAT-O raw p-values.
-
-        ARCH-03: FDR is applied only to ACAT-O p-values (not per-test).
-        With a single test (fisher), ACAT-O p-values are pass-throughs of fisher p-values,
-        so the corrected ACAT-O values match FDR of fisher p-values directly.
-        """
+        """Fisher q-values match direct smm.multipletests on Fisher raw p-values."""
         import statsmodels.stats.multitest as smm
 
         genes = [
@@ -228,15 +223,21 @@ class TestFisherBitIdentitySamplesMode:
         engine = AssociationEngine.from_names(["fisher"], config)
         result_df = engine.run_all(genes)
 
-        # Primary test has no corrected_p_value column (ARCH-03)
         assert "fisher_corrected_p_value" not in result_df.columns
+        assert "acat_o_pvalue" not in result_df.columns
+        assert "acat_o_qvalue" not in result_df.columns
 
-        # ACAT-O corrected values should match FDR applied to ACAT-O raw p-values
-        raw_acat_pvals = result_df["acat_o_pvalue"].values
-        expected_corrected = smm.multipletests(raw_acat_pvals, method="fdr_bh")[1]
+        expected_corrected = smm.multipletests(result_df["fisher_pvalue"].values, method="fdr_bh")[
+            1
+        ]
 
         np.testing.assert_array_almost_equal(
-            result_df["acat_o_qvalue"].values,
+            result_df["fisher_qvalue"].values,
+            expected_corrected,
+            decimal=15,
+        )
+        np.testing.assert_array_almost_equal(
+            result_df["primary_qvalue"].values,
             expected_corrected,
             decimal=15,
         )

--- a/tests/unit/test_association_stage.py
+++ b/tests/unit/test_association_stage.py
@@ -19,6 +19,7 @@ from variantcentrifuge.pipeline_core.workspace import Workspace
 from variantcentrifuge.stages.analysis_stages import (
     AssociationAnalysisStage,
     GeneBurdenAnalysisStage,
+    _count_significant_association_results,
 )
 
 # ---------------------------------------------------------------------------
@@ -225,7 +226,7 @@ class TestAssociationAnalysisStageRun:
     def test_association_results_has_expected_columns(
         self, mock_workspace, minimal_df, case_control_config
     ):
-        """association_results DataFrame has gene, fisher_p_value, fisher_or columns."""
+        """association_results DataFrame has gene, Fisher, and primary result columns."""
         context = _make_context(case_control_config, minimal_df, mock_workspace)
 
         stage = AssociationAnalysisStage()
@@ -234,7 +235,23 @@ class TestAssociationAnalysisStageRun:
         df = result.association_results
         assert "gene" in df.columns
         assert "fisher_pvalue" in df.columns
+        assert "fisher_qvalue" in df.columns
         assert "fisher_or" in df.columns
+        assert "primary_pvalue" in df.columns
+        assert "primary_qvalue" in df.columns
+        assert "acat_o_qvalue" not in df.columns
+
+    def test_summary_significance_count_uses_primary_qvalue(self):
+        """Unweighted aliases must not make the summary disagree with primary q-values."""
+        results_df = pd.DataFrame(
+            {
+                "primary_qvalue": [0.20, 0.08],
+                "fisher_weighted_qvalue": [0.20, 0.08],
+                "fisher_unweighted_qvalue": [0.001, 0.20],
+            }
+        )
+
+        assert _count_significant_association_results(results_df) == 0
 
     def test_association_config_key_used_not_perform_gene_burden(
         self, mock_workspace, minimal_df, tmp_path

--- a/tests/unit/test_coast.py
+++ b/tests/unit/test_coast.py
@@ -1018,8 +1018,8 @@ class TestCOASTEngineRegistration:
         registry = _build_registry()
         assert registry["coast"] is COASTTest
 
-    def test_acat_o_includes_coast_pvalue(self):
-        """When coast is a registered test, ACAT-O combines coast_pvalue."""
+    def test_single_coast_uses_coast_primary_qvalue(self):
+        """Single-test COAST runs expose the COAST result as primary."""
         from variantcentrifuge.association.base import AssociationConfig, TestResult
         from variantcentrifuge.association.engine import AssociationEngine
 
@@ -1068,13 +1068,14 @@ class TestCOASTEngineRegistration:
 
         result_df = engine.run_all(gene_data)
 
-        # ACAT-O should have combined the coast p-value
-        assert "acat_o_pvalue" in result_df.columns
-        # With only one test (coast), ACAT-O = coast p-value (single p-value pass-through)
-        assert result_df["acat_o_pvalue"].iloc[0] is not None
-        # coast_pvalue column should be present
+        # Single-test COAST output uses the COAST result directly, not ACAT-O pass-through.
+        assert "acat_o_pvalue" not in result_df.columns
         assert "coast_pvalue" in result_df.columns
+        assert "coast_qvalue" in result_df.columns
+        assert "primary_pvalue" in result_df.columns
+        assert "primary_qvalue" in result_df.columns
         assert result_df["coast_pvalue"].iloc[0] == pytest.approx(0.01)
+        assert result_df["primary_pvalue"].iloc[0] == pytest.approx(0.01)
 
     def test_coast_extra_columns_in_engine_output(self):
         """coast_burden_pvalue, coast_skat_pvalue, coast_n_* appear in engine output."""

--- a/tests/unit/test_engine_skat_integration.py
+++ b/tests/unit/test_engine_skat_integration.py
@@ -189,6 +189,10 @@ class TestSKATColumnStructure:
         assert "skat_corrected_pvalue" not in result.columns
         assert "acat_o_pvalue" in result.columns
         assert "acat_o_qvalue" in result.columns
+        assert "primary_test" in result.columns
+        assert "primary_pvalue" in result.columns
+        assert "primary_qvalue" in result.columns
+        assert set(result["primary_test"]) == {"acat_o"}
 
     def test_engine_skat_extra_columns_written(self):
         """Extra SKAT columns (skat_o_rho, skat_method) are written to output."""
@@ -483,6 +487,9 @@ class TestSKATColumnCount:
             # ARCH-03: no skat_corrected_pvalue; ACAT-O is the single corrected output
             "acat_o_pvalue",
             "acat_o_qvalue",
+            "primary_test",
+            "primary_pvalue",
+            "primary_qvalue",
             "skat_o_rho",
             "skat_method",
             "skat_warnings",

--- a/variantcentrifuge/association/engine.py
+++ b/variantcentrifuge/association/engine.py
@@ -4,9 +4,9 @@
 AssociationEngine — orchestrator for multi-test rare variant association.
 
 The engine accepts a list of AssociationTest instances, runs each test on
-every gene in the input data, computes ACAT-O omnibus p-values per gene,
-applies a single round of multiple testing correction to ACAT-O p-values
-(ARCH-03), and returns a wide-format DataFrame with one row per gene.
+every gene in the input data, chooses a primary association p-value per gene,
+applies one round of multiple testing correction to that primary p-value, and
+returns a wide-format DataFrame with one row per gene.
 
 Column naming convention: {test_name}_{field}, e.g.:
   fisher_pvalue, fisher_or,
@@ -21,14 +21,18 @@ ACAT-O columns (Phase 22):
   acat_o_pvalue  — raw omnibus Cauchy combination of per-test p-values
   acat_o_qvalue  — FDR/Bonferroni corrected across all genes
 
+Primary columns:
+  primary_test    — corrected significance target ("fisher", "acat_o", etc.)
+  primary_pvalue  — raw p-value used for multiple testing correction
+  primary_qvalue  — corrected primary p-value
+
 SKAT-O note: when skat_method="SKATO", the skat_pvalue column is renamed to
   skat_o_pvalue to distinguish SKAT-O from the plain SKAT result.
 
-FDR strategy (ARCH-03):
-  Single correction pass on ACAT-O p-values only. Individual test p-values
-  (fisher, burden, skat) remain uncorrected — they exist for diagnostic signal
-  decomposition, not independent hypothesis testing. corrected_p_value on
-  primary TestResult objects is always None.
+FDR strategy:
+  Single correction pass on the primary p-value only. For multi-test runs and
+  SKAT runs this is ACAT-O. For single non-SKAT tests, the primary p-value is
+  the test's own p-value, avoiding misleading ACAT-O aliases for pass-throughs.
 
 Shared columns (gene-level metadata, not test-specific):
   gene, n_cases, n_controls, n_variants
@@ -153,6 +157,13 @@ def _apply_builder_result_to_gene_data(
 def _discard_per_gene_matrix_payload(gene_data: dict[str, Any]) -> None:
     for key in _PER_GENE_MATRIX_PAYLOAD_KEYS:
         gene_data.pop(key, None)
+
+
+def _single_test_output_id(test_name: str, result: TestResult | None) -> str:
+    """Return the user-facing column prefix for a single-test primary result."""
+    if test_name == "skat" and result is not None and result.extra.get("skat_method") == "SKATO":
+        return "skat_o"
+    return test_name
 
 
 class AssociationEngine:
@@ -363,10 +374,9 @@ class AssociationEngine:
         """
         Run all registered tests across all genes and return wide-format results.
 
-        FDR correction (ARCH-03): applied only to ACAT-O p-values across all
-        genes. Primary test columns (fisher_pvalue, burden_pvalue, etc.) are
-        uncorrected — they are diagnostic signal decomposition, not independent
-        hypotheses. corrected_p_value on primary TestResults is always None.
+        FDR correction is applied once to the primary p-value across all genes.
+        Multi-test and SKAT runs use ACAT-O as the primary result. Single
+        non-SKAT runs use the test's own p-value as the primary result.
 
         Parameters
         ----------
@@ -381,9 +391,9 @@ class AssociationEngine:
             Wide-format results. One row per gene that has at least one test
             result (genes where all tests returned p_value=None are excluded).
             Columns: gene, n_cases, n_controls, n_variants, then per-test
-            columns: {test}_pvalue (uncorrected), plus test-aware effect
-            columns (e.g. fisher_or or logistic_burden_beta), and finally
-            acat_o_pvalue and acat_o_qvalue.
+            columns: {test}_pvalue, plus test-aware effect columns (e.g.
+            fisher_or or logistic_burden_beta), and primary_pvalue/primary_qvalue.
+            ACAT-O columns are present only when ACAT-O is the primary result.
         """
         if not gene_burden_data:
             logger.warning("No gene burden data provided to AssociationEngine.")
@@ -517,30 +527,45 @@ class AssociationEngine:
         for test in self._tests.values():
             test.finalize()
 
-        # --- ARCH-03: Single FDR pass on ACAT-O only ---
-        # Primary tests do NOT get corrected_p_value — they are diagnostic decomposition,
-        # not independent hypotheses. ACAT-O is the single omnibus significance measure.
+        if not self._tests:
+            logger.warning("Association analysis: no association tests registered.")
+            return pd.DataFrame()
 
-        # Step 1: Compute ACAT-O p-values (post-loop meta-test)
-        acat_o_results = self._compute_acat_o(results_by_test, sorted_data)
-        results_by_test["acat_o"] = acat_o_results
+        # Single correction pass on the run's primary p-value.
+        #
+        # ACAT-O is the right primary result for multi-test runs. It also stays
+        # primary for SKAT because the engine can include ACAT-V in that omnibus
+        # combination. For single non-SKAT tests, ACAT-O would be a pure
+        # pass-through, so correction is attached to the actual test result
+        # (for example fisher_qvalue) instead of misleading acat_o_* columns.
+        primary_result_id = next(iter(self._tests))
+        write_acat_o = len(self._tests) > 1 or "skat" in self._tests
+        acat_o_results: dict[str, TestResult] = {}
+        correction_results: dict[str, TestResult]
+        if write_acat_o:
+            acat_o_results = self._compute_acat_o(results_by_test, sorted_data)
+            results_by_test["acat_o"] = acat_o_results
+            correction_results = acat_o_results
+            primary_result_id = "acat_o"
+        else:
+            correction_results = results_by_test[primary_result_id]
 
-        # Step 2: Apply FDR correction to ACAT-O p-values only
         gene_order = [d.get("GENE", "") for d in sorted_data]
         testable_genes = [
             g
             for g in gene_order
-            if acat_o_results.get(g) is not None and acat_o_results[g].p_value is not None
+            if correction_results.get(g) is not None and correction_results[g].p_value is not None
         ]
 
         # Phase 33: weighted or unweighted correction path
         fdr_weights_by_gene: dict[str, float] = {}
         unweighted_corrected_by_gene: dict[str, float] = {}
+        weighted_corrected_by_gene: dict[str, float] = {}
         weighted_norm_arr: list[float] = []
 
         if testable_genes:
             raw_pvals: list[float] = [
-                acat_o_results[g].p_value  # type: ignore[misc]
+                correction_results[g].p_value  # type: ignore[misc]
                 for g in testable_genes
             ]
 
@@ -569,6 +594,8 @@ class AssociationEngine:
                 weighted_norm_arr = norm_w.tolist()
                 for g, nw in zip(testable_genes, norm_w, strict=True):
                     fdr_weights_by_gene[g] = float(nw)
+                for g, wt in zip(testable_genes, corrected, strict=True):
+                    weighted_corrected_by_gene[g] = float(wt)
 
                 # Write diagnostics if requested (Phase 33)
                 diag_out = getattr(self._config, "diagnostics_output", None)
@@ -598,7 +625,7 @@ class AssociationEngine:
                 corrected = apply_correction(raw_pvals, self._config.correction_method)
 
             for gene, corr_p in zip(testable_genes, corrected, strict=True):
-                acat_o_results[gene].corrected_p_value = float(corr_p)
+                correction_results[gene].corrected_p_value = float(corr_p)
 
         # Build wide-format DataFrame
         rows = []
@@ -629,8 +656,9 @@ class AssociationEngine:
                 res = results_by_test[test_name][gene]
                 col_names = test.effect_column_names()
                 row[f"{test_name}_pvalue"] = res.p_value
-                # Primary test corrected_p_value is always None (ARCH-03)
-                # It is written for schema completeness but remains None.
+                # Corrected significance is emitted through primary_* columns
+                # and, for single-test runs, through {test}_qvalue aliases.
+                # Do not reintroduce legacy {test}_corrected_pvalue columns.
                 # None-effect guard: skip column creation when effect/CI names are None.
                 # Required for SKAT which has no effect size, SE, or confidence interval.
                 # Without this guard, col_names['effect'] = None would produce
@@ -656,10 +684,41 @@ class AssociationEngine:
                 if res.extra.get("skat_method") == "SKATO" and f"{test_name}_pvalue" in row:
                     row[f"{test_name}_o_pvalue"] = row.pop(f"{test_name}_pvalue")
 
-            # ACAT-O columns (Phase 22) — omnibus significance measure
-            acat_res = acat_o_results.get(gene)
-            row["acat_o_pvalue"] = acat_res.p_value if acat_res is not None else None
-            row["acat_o_qvalue"] = acat_res.corrected_p_value if acat_res is not None else None
+            # Primary significance columns. In single-test pass-through mode,
+            # also expose a test-specific q-value such as fisher_qvalue.
+            primary_res = correction_results.get(gene)
+            primary_output_id = primary_result_id
+            if not write_acat_o:
+                primary_output_id = _single_test_output_id(primary_result_id, primary_res)
+                row[f"{primary_output_id}_qvalue"] = (
+                    primary_res.corrected_p_value if primary_res is not None else None
+                )
+                if weighted_corrected_by_gene:
+                    row[f"{primary_output_id}_weighted_qvalue"] = weighted_corrected_by_gene.get(
+                        gene
+                    )
+                    row[f"{primary_output_id}_unweighted_qvalue"] = (
+                        unweighted_corrected_by_gene.get(gene)
+                    )
+
+            row["primary_test"] = primary_output_id
+            row["primary_pvalue"] = primary_res.p_value if primary_res is not None else None
+            row["primary_qvalue"] = (
+                primary_res.corrected_p_value if primary_res is not None else None
+            )
+            if weighted_corrected_by_gene:
+                row["primary_weighted_qvalue"] = weighted_corrected_by_gene.get(gene)
+                row["primary_unweighted_qvalue"] = unweighted_corrected_by_gene.get(gene)
+
+            # ACAT-O columns are only emitted when ACAT-O is a real primary
+            # result, not for single-test pass-throughs such as Fisher-only.
+            if write_acat_o:
+                acat_res = acat_o_results.get(gene)
+                row["acat_o_pvalue"] = acat_res.p_value if acat_res is not None else None
+                row["acat_o_qvalue"] = acat_res.corrected_p_value if acat_res is not None else None
+                if weighted_corrected_by_gene:
+                    row["acat_o_weighted_qvalue"] = weighted_corrected_by_gene.get(gene)
+                    row["acat_o_unweighted_qvalue"] = unweighted_corrected_by_gene.get(gene)
 
             # Phase 33: fdr_weight column — only added when weighted BH is active
             if fdr_weights_by_gene:
@@ -672,9 +731,9 @@ class AssociationEngine:
             return pd.DataFrame()
 
         result_df = pd.DataFrame(rows)
-        n_sig = (result_df.get("acat_o_qvalue", pd.Series(dtype=float)) < 0.05).sum()
+        n_sig = (result_df.get("primary_qvalue", pd.Series(dtype=float)) < 0.05).sum()
         logger.info(
             f"Association analysis complete: {len(result_df)} genes tested, "
-            f"{n_sig} significant (ACAT-O corrected p < 0.05)"
+            f"{n_sig} significant (primary corrected p < 0.05)"
         )
         return result_df

--- a/variantcentrifuge/stages/analysis_stages.py
+++ b/variantcentrifuge/stages/analysis_stages.py
@@ -2428,6 +2428,17 @@ def _build_assoc_config_from_context(context: "PipelineContext") -> AssociationC
     )
 
 
+def _count_significant_association_results(
+    results_df: pd.DataFrame,
+    threshold: float = 0.05,
+) -> int:
+    """Count significant association rows using the run's primary corrected p-value."""
+    if "primary_qvalue" in results_df.columns:
+        return int((results_df["primary_qvalue"] < threshold).sum())
+    corr_cols = [c for c in results_df.columns if c.endswith("_qvalue")]
+    return int((results_df[corr_cols].min(axis=1) < threshold).sum()) if corr_cols else 0
+
+
 class AssociationAnalysisStage(Stage):
     """Perform association analysis using the modular AssociationEngine framework."""
 
@@ -2902,9 +2913,7 @@ class AssociationAnalysisStage(Stage):
 
         # Log summary
         n_genes = len(results_df)
-        # Count significant genes across any corrected p-value column
-        corr_cols = [c for c in results_df.columns if c.endswith("_qvalue")]
-        n_sig = int((results_df[corr_cols].min(axis=1) < 0.05).sum()) if corr_cols else 0
+        n_sig = _count_significant_association_results(results_df)
         logger.info(
             f"Association analysis: {n_genes} genes tested, {n_sig} significant (FDR < 0.05)"
         )


### PR DESCRIPTION
## Summary

Fixes #108 by separating the corrected primary association result from ACAT-O pass-through output.

- Fisher-only and other single non-SKAT runs now expose corrected values as `<test>_qvalue` plus `primary_qvalue`.
- Fisher-only weighted FDR now writes `fisher_qvalue`, `fisher_weighted_qvalue`, `fisher_unweighted_qvalue`, and matching `primary_*` aliases instead of `acat_o_qvalue`.
- ACAT-O columns remain for real omnibus targets: multi-test runs and SKAT runs.
- Association-stage significance summaries now count `primary_qvalue`, avoiding false summaries from unweighted alias columns.
- Docs and FAQ now direct users to `primary_qvalue` and Fisher-specific q-value columns for Fisher-only runs.

## Root Cause

`AssociationEngine.run_all()` always computed ACAT-O and corrected `acat_o_pvalue`. With a single Fisher test, ACAT-O is a single-p-value pass-through, so weighted Fisher FDR was stored under ACAT-O-named columns.

## Validation

- `ruff check variantcentrifuge/association/engine.py variantcentrifuge/stages/analysis_stages.py tests/unit/test_association_engine.py tests/unit/test_association_fisher.py tests/unit/test_engine_skat_integration.py tests/unit/test_association_stage.py tests/unit/test_coast.py`
- `pytest tests/unit/test_association_engine.py -q`
- `pytest tests/unit/test_association_fisher.py -q`
- `pytest tests/unit/test_engine_skat_integration.py -q`
- `pytest tests/unit/test_association_stage.py tests/unit/test_weighted_correction.py -q`
- `pytest tests/unit/test_coast.py -q`
- `pytest tests/unit/test_score_column_association_integration.py -q`
- `pytest tests/unit/test_association_diagnostics.py -q`
- `pytest tests/unit -q` (1768 passed)
