### PR TITLE
Fix checkpoint resume state restoration

### DIFF
--- a/docs/source/resume_system.md
+++ b/docs/source/resume_system.md
@@ -50,7 +50,8 @@ Each pipeline stage follows this checkpoint lifecycle:
 2. **Process**: Stage performs its main work
 3. **Finalize** (optional): Stage enters `finalizing` state while moving temp files to final locations
 4. **Complete**: Stage finishes, marked as `completed` with output files recorded
-5. **Skip**: On resume, completed stages are skipped and their state is restored
+5. **Resume action**: On resume, completed stages are restored, skipped, or
+   recomputed according to their explicit checkpoint resume policy
 
 ### Atomic File Operations
 
@@ -112,36 +113,93 @@ variantcentrifuge --enable-checkpoint --checkpoint-checksum [other options]
 
 ## Stage Types and Resume Behavior
 
-### File-Based Stages
+Completed checkpoint entries are not all equivalent after a process restart. Some
+stages only produce durable files, while others mutate in-memory DataFrames that no
+longer exist in the resumed process. VariantCentrifuge uses an explicit resume policy
+for each stage:
 
-Stages that produce output files (e.g., `parallel_complete_processing`, `genotype_replacement`):
+- `restore`: the stage may be skipped only after `_handle_checkpoint_skip()` rebuilds
+  the downstream context state from durable artifacts.
+- `skip`: the stage has no downstream runtime state to restore, or is an intentional
+  no-op in the current configuration.
+- `recompute`: the completed checkpoint entry is not trusted after process restart; the
+  stage and downstream stages are re-executed.
+
+The conservative default is `recompute`.
+
+### Durable File Stages
+
+Stages that produce durable output files can be restored only when those files exist and
+validate. Missing expected artifacts abort resume instead of logging a warning and
+continuing.
+
+Example: `parallel_complete_processing` restores the merged extracted TSV and marks the
+constituent extraction/filtering stages complete only after the merged TSV validates:
 
 ```python
-# Example: GenotypeReplacementStage
+# Example: ParallelCompleteProcessingStage
 def _handle_checkpoint_skip(self, context: PipelineContext) -> PipelineContext:
-    """Restore file paths when stage is skipped."""
-    output_tsv = context.workspace.get_intermediate_path(
-        f"{context.workspace.base_name}.genotype_replaced.tsv.gz"
-    )
-    if output_tsv.exists():
-        context.genotype_replaced_tsv = output_tsv
-        context.data = output_tsv
+    if not merged_tsv.exists() or not self._validate_chunk_tsv(merged_tsv):
+        raise RuntimeError("Cannot restore parallel_complete_processing from checkpoint")
+
+    context.extracted_tsv = merged_tsv
+    context.data = merged_tsv
+    context.config["parallel_vcf_processing_complete"] = True
+    context.mark_complete("variant_extraction")
+    context.mark_complete("field_extraction")
+    context.mark_complete("snpsift_filtering")
     return context
 ```
 
-### Memory-Based Stages
+`GenotypeReplacementStage` is a Phase-11 no-op. Its resume skip is therefore a clean
+no-op and does not require a `genotype_replaced.tsv` file.
 
-Stages that work with DataFrames (e.g., `dataframe_loading`, `custom_annotation`):
+### Restorable Memory Stages
+
+Some memory-based stages can rebuild their runtime state from durable TSV artifacts.
+`dataframe_loading` reloads the current DataFrame when full loading is appropriate, or
+defers to `chunked_analysis` for large files. `chunked_analysis` restores
+`context.current_dataframe` from `chunked_analysis_results.tsv(.gz)`, including
+header-only empty results.
 
 ```python
 # Example: DataFrameLoadingStage
 def _handle_checkpoint_skip(self, context: PipelineContext) -> PipelineContext:
-    """Restore DataFrame from TSV file when stage is skipped."""
     input_file = self._find_input_file(context)
-    df = pd.read_csv(input_file, sep="\t", dtype=str, compression="gzip")
+    if not input_file or not Path(input_file).exists():
+        raise RuntimeError("Cannot restore dataframe_loading from checkpoint")
+
+    if self._should_use_chunks(context, input_file) and not context.config.get(
+        "dataframe_chunked_analysis_complete", False
+    ):
+        context.config["use_chunked_processing"] = True
+        return context
+
+    df, rename_map = load_optimized_dataframe(str(input_file), sep="\t")
     context.current_dataframe = df
+    context.column_rename_map = rename_map
     return context
 ```
+
+The old `chunked_processing_complete` meaning has been split:
+
+- `parallel_vcf_processing_complete`: VCF chunk extraction/filter/merge is complete.
+- `dataframe_chunked_analysis_complete`: DataFrame chunked analysis has produced a
+  restorable DataFrame TSV.
+
+The parallel VCF flag does not suppress DataFrame chunking.
+
+### Volatile Memory Stages
+
+Stages such as custom annotation, inheritance analysis, variant analysis, scoring,
+final filtering, pseudonymization, and ClinVar PM5 mutate DataFrames in memory without
+durable post-stage DataFrame artifacts. After process restart, these stages are
+recomputed even if the checkpoint says they were completed.
+
+This recompute behavior must clear the persisted checkpoint completion for the first
+volatile stage and all downstream stages, because both `PipelineRunner` and
+`Stage.__call__()` can skip completed checkpoint stages. Clearing only in-memory
+`PipelineContext.completed_stages` is not sufficient.
 
 ### Composite Stages
 
@@ -161,6 +219,17 @@ def _handle_checkpoint_skip(self, context: PipelineContext) -> PipelineContext:
 
     return context
 ```
+
+### Required Outputs and Empty Results
+
+Requested analysis and output stages fail when required runtime state is missing. For
+example, requested association, gene burden, statistics, TSV output, and Excel output
+do not mark their checkpoint stage complete when `context.current_dataframe` or the
+required TSV artifact is absent.
+
+An empty DataFrame is different from a missing DataFrame. Valid zero-row results produce
+header-only requested outputs, including final TSV, association sidecar, and gene burden
+sidecar files.
 
 ## Resume Validation
 
@@ -274,6 +343,16 @@ variantcentrifuge --gene-name PKD1 --vcf-file input.vcf.gz \
     --enable-checkpoint --resume-from variant_analysis
 ```
 
+`--resume-from STAGE` uses restart semantics: the target stage and all subsequent stages
+are re-executed. The target can be a previously failed or incomplete stage. Before the
+target, the runner restores only safe durable/restorable prerequisites. If the requested
+target depends on volatile in-memory state that cannot be restored, resume fails with an
+earlier safe stage to use instead, such as `--resume-from dataframe_loading`.
+
+For issue #101-style runs, fixing resume state restoration can correctly expose the
+original `association_analysis` failure again. That association categorical genotype
+error is separate from checkpoint resume correctness.
+
 ### Development Workflow
 
 ```bash
@@ -343,6 +422,16 @@ Output file validation failed for step 'stage_name': /path/to/file.tsv
 ```
 
 **Solution**: Check that intermediate files weren't manually deleted. Remove checkpoint file to start fresh.
+
+#### Missing Required Checkpoint Artifact
+
+```
+Cannot restore chunked_analysis from checkpoint: chunked output missing
+```
+
+**Solution**: Resume from an earlier durable stage that can regenerate the missing
+artifact, or start fresh. The pipeline intentionally aborts rather than reporting
+success with missing requested outputs.
 
 #### Corrupted Checkpoint
 
@@ -447,12 +536,12 @@ Stages integrate with the checkpoint system through:
 ```python
 class Stage(ABC):
     def __call__(self, context: PipelineContext) -> PipelineContext:
-        # Check if stage should be skipped
+        # Stage.__call__ has its own checkpoint skip gate. The runner clears
+        # persisted completion first for recompute stages so this gate cannot
+        # skip volatile in-memory work after process restart.
         if context.checkpoint_state.should_skip_step(self.name):
             context.mark_complete(self.name)
-
-            # Restore state if needed
-            if hasattr(self, '_handle_checkpoint_skip'):
+            if hasattr(self, "_handle_checkpoint_skip"):
                 context = self._handle_checkpoint_skip(context)
 
             return context

--- a/docs/superpowers/plans/2026-05-16-checkpoint-resume-state-restoration.md
+++ b/docs/superpowers/plans/2026-05-16-checkpoint-resume-state-restoration.md
@@ -1,0 +1,729 @@
+# Checkpoint Resume State Restoration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans`.
+> For parallel work, use `superpowers:subagent-driven-development` with disjoint file
+> ownership. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Fix issue #101 so checkpoint resume cannot report success unless required
+runtime state is restored or required outputs are produced.
+
+**Architecture:** Make checkpoint resume policy explicit. Completed stages may be
+skipped only when downstream state is durable or restorable. Volatile in-memory
+DataFrame stages must have their persisted checkpoint completion cleared and then be
+re-executed. Requested analysis/output stages fail on missing required runtime state,
+but valid zero-row DataFrames write header-only outputs.
+
+**Tech Stack:** Python, pytest, pandas, VariantCentrifuge pipeline runner and checkpoint
+system.
+
+---
+
+## Files
+
+- Modify `variantcentrifuge/pipeline_core/stage.py`
+  - Record checkpoint failures in `Stage.__call__()`.
+  - Add a conservative checkpoint resume policy hook.
+- Modify `variantcentrifuge/checkpoint.py`
+  - Make `fail_step()` thread-safe.
+  - Allow `--resume-from` to target failed/stale/incomplete stages when safe.
+  - Add small status/downstream clearing helpers if useful.
+- Modify `variantcentrifuge/pipeline_core/runner.py`
+  - Replace blind resume pre-marking with policy-aware restore/recompute planning.
+  - Clear recompute-stage checkpoint completion persistently so `Stage.__call__()` does
+    not skip through its own checkpoint gate.
+  - Replace the hard-coded selective-resume prerequisite stage set with policy logic.
+- Modify `variantcentrifuge/stages/processing_stages.py`
+  - Harden `ParallelCompleteProcessingStage._handle_checkpoint_skip()`.
+  - Split parallel VCF completion state from DataFrame chunked-analysis completion.
+  - Make `GenotypeReplacementStage` resume skip a clean Phase-11 no-op.
+  - Keep `PhenotypeIntegrationStage` artifact checks conditional on real output.
+- Modify `variantcentrifuge/stages/analysis_stages.py`
+  - Harden `DataFrameLoadingStage._handle_checkpoint_skip()`.
+  - Add `ChunkedAnalysisStage._handle_checkpoint_skip()`.
+  - Split `dataframe_chunked_analysis_complete` from parallel VCF processing.
+  - Fail requested association/gene-burden/statistics stages on missing DataFrame.
+  - Write header-only association/gene-burden outputs for valid empty DataFrames.
+- Modify `variantcentrifuge/stages/output_stages.py`
+  - Fail `TSVOutputStage` on missing DataFrame and missing chunked output.
+  - Fail requested Excel generation on missing final TSV.
+  - Add checkpoint output-file tracking for TSV/Excel/metadata reports.
+- Modify `variantcentrifuge/pipeline.py`
+  - Add final output validation before logging successful completion.
+- Modify `docs/source/resume_system.md`
+  - Document durable/restorable/recompute resume policies.
+  - Document safe failed-stage `--resume-from` behavior.
+- Add or modify tests under:
+  - `tests/unit/pipeline/test_stage.py`
+  - `tests/unit/pipeline/test_runner.py`
+  - `tests/unit/test_parallel_stage_resume.py`
+  - `tests/unit/stages/test_analysis_stages.py`
+  - `tests/unit/stages/test_output_stages.py`
+  - `tests/unit/test_association_stage.py`
+  - `tests/unit/test_gene_burden_regression.py` or a focused gene-burden stage test
+  - `tests/test_checkpoint.py`
+  - `tests/integration/test_checkpoint_resume_state_restoration.py`
+
+---
+
+## Task 1: Prove Stage Failures Are Not Recorded
+
+**Files:**
+- Modify `tests/unit/pipeline/test_stage.py`
+
+- [x] Add `test_stage_failure_marks_checkpoint_failed`.
+
+Test sketch:
+
+```python
+class FailingStage(Stage):
+    @property
+    def name(self):
+        return "failing_stage"
+
+    def _process(self, context):
+        raise ValueError("boom")
+
+
+context.checkpoint_state = Mock()
+
+with pytest.raises(ValueError, match="boom"):
+    FailingStage()(context)
+
+context.checkpoint_state.start_step.assert_called_once()
+context.checkpoint_state.fail_step.assert_called_once_with("failing_stage", "boom")
+context.checkpoint_state.complete_step.assert_not_called()
+```
+
+- [x] Run and confirm the test fails:
+
+```bash
+pytest tests/unit/pipeline/test_stage.py -q
+```
+
+---
+
+## Task 2: Record Failures And Lock `fail_step()`
+
+**Files:**
+- Modify `variantcentrifuge/pipeline_core/stage.py`
+- Modify `variantcentrifuge/checkpoint.py`
+
+- [x] In `Stage.__call__()` exception handling, record failure without hiding the
+  original exception:
+
+```python
+except Exception as e:
+    elapsed = time.time() - start_time
+    if context.checkpoint_state:
+        try:
+            context.checkpoint_state.fail_step(self.name, str(e))
+        except Exception as checkpoint_error:
+            logger.warning(
+                "Failed to record checkpoint failure for stage '%s': %s",
+                self.name,
+                checkpoint_error,
+            )
+    logger.error(f"Stage '{self.name}' failed after {elapsed:.1f}s: {e}")
+    raise
+```
+
+- [x] Wrap `PipelineState.fail_step()` body in `with self._state_lock:` and call
+  `self.save()` after releasing the lock, matching the `start_step()` and
+  `complete_step()` pattern.
+- [x] Audit current process-pool behavior. If checkpoint-relevant stages can execute in a
+  child process, add a TODO or guard so parent-side checkpoint state remains authoritative.
+- [x] Run:
+
+```bash
+pytest tests/unit/pipeline/test_stage.py tests/test_checkpoint.py -q
+```
+
+---
+
+## Task 3: Prove Flag Split And Parallel Skip Requirements
+
+**Files:**
+- Modify `tests/unit/test_parallel_stage_resume.py`
+- Modify `tests/unit/stages/test_analysis_stages.py`
+
+- [x] Add `test_handle_checkpoint_skip_restores_parallel_vcf_completion_only`.
+
+Expected:
+
+```python
+result.extracted_tsv == merged_tsv
+result.data == merged_tsv
+result.config["parallel_vcf_processing_complete"] is True
+assert "dataframe_chunked_analysis_complete" not in result.config
+```
+
+- [x] Add `test_parallel_skip_does_not_suppress_dataframe_chunking`.
+
+Set up `DataFrameLoadingStage._should_use_chunks()` to return `True` after
+`ParallelCompleteProcessingStage._handle_checkpoint_skip()`. Expected:
+
+```python
+DataFrameLoadingStage()._handle_checkpoint_skip(context)
+assert context.config["use_chunked_processing"] is True
+assert context.current_dataframe is None
+```
+
+- [x] Add `test_handle_checkpoint_skip_raises_for_missing_merged_tsv`.
+
+Expected:
+
+```python
+with pytest.raises(RuntimeError, match="Cannot restore parallel_complete_processing"):
+    stage._handle_checkpoint_skip(context)
+```
+
+- [x] Run and confirm failures:
+
+```bash
+pytest tests/unit/test_parallel_stage_resume.py tests/unit/stages/test_analysis_stages.py -q
+```
+
+---
+
+## Task 4: Implement Flag Split And Harden Processing Skips
+
+**Files:**
+- Modify `variantcentrifuge/stages/processing_stages.py`
+- Modify `variantcentrifuge/stages/analysis_stages.py`
+
+- [x] Replace the parallel VCF completion write:
+
+```python
+# ParallelCompleteProcessingStage._process() and _handle_checkpoint_skip()
+context.config["parallel_vcf_processing_complete"] = True
+context.config.pop("chunked_processing_complete", None)  # only if safe in local tests
+```
+
+If removing the legacy key immediately breaks unrelated tests, keep a compatibility read
+elsewhere but do not let this key suppress DataFrame chunking.
+
+- [x] In `ParallelCompleteProcessingStage._handle_checkpoint_skip()`, validate before
+  mutating context:
+
+```python
+if not merged_tsv.exists() or not self._validate_chunk_tsv(merged_tsv):
+    raise RuntimeError(
+        "Cannot restore parallel_complete_processing from checkpoint: "
+        f"merged TSV missing or invalid: {merged_tsv}"
+    )
+
+context.extracted_tsv = merged_tsv
+context.data = merged_tsv
+context.config["parallel_vcf_processing_complete"] = True
+context.mark_complete("variant_extraction")
+context.mark_complete("snpsift_filtering")
+context.mark_complete("field_extraction")
+```
+
+- [x] Update `DataFrameLoadingStage` chunking checks to use:
+
+```python
+dataframe_chunks_done = context.config.get("dataframe_chunked_analysis_complete", False)
+if self._should_use_chunks(context, input_file) and not dataframe_chunks_done:
+    context.config["use_chunked_processing"] = True
+    return context
+```
+
+- [x] Make `GenotypeReplacementStage._handle_checkpoint_skip()` a clean no-op because
+  `_process()` is a Phase-11 no-op:
+
+```python
+logger.info("Genotype replacement is a Phase-11 no-op; nothing to restore")
+return context
+```
+
+- [x] For `PhenotypeIntegrationStage._handle_checkpoint_skip()`, raise only when
+  phenotype data/config means the stage should have produced a TSV. If no phenotype data
+  is configured, return cleanly.
+- [x] Run:
+
+```bash
+pytest tests/unit/test_parallel_stage_resume.py tests/unit/stages/test_analysis_stages.py -q
+```
+
+---
+
+## Task 5: Prove DataFrame And Chunked Analysis Restoration
+
+**Files:**
+- Modify `tests/unit/stages/test_analysis_stages.py`
+
+- [x] Add `test_dataframe_loading_skip_raises_when_no_tsv_available`.
+- [x] Add `test_dataframe_loading_skip_defers_to_chunked_analysis_for_large_tsv`.
+- [x] Add `test_chunked_analysis_skip_restores_dataframe_from_artifact`.
+- [x] Add `test_chunked_analysis_skip_restores_header_only_empty_dataframe`.
+- [x] Add `test_chunked_analysis_skip_raises_when_artifact_missing`.
+
+Expected for valid chunked restore:
+
+```python
+result = ChunkedAnalysisStage()._handle_checkpoint_skip(context)
+assert result.current_dataframe is not None
+assert result.chunked_analysis_tsv == chunked_tsv
+assert result.config["dataframe_chunked_analysis_complete"] is True
+```
+
+- [x] Run and confirm failures:
+
+```bash
+pytest tests/unit/stages/test_analysis_stages.py -q
+```
+
+---
+
+## Task 6: Implement DataFrame And Chunked Restore
+
+**Files:**
+- Modify `variantcentrifuge/stages/analysis_stages.py`
+
+- [x] Harden `DataFrameLoadingStage._handle_checkpoint_skip()`:
+
+```python
+input_file = self._find_input_file(context)
+if not input_file or not Path(input_file).exists():
+    raise RuntimeError(
+        "Cannot restore dataframe_loading from checkpoint: no TSV input file found"
+    )
+
+if self._should_use_chunks(context, input_file) and not context.config.get(
+    "dataframe_chunked_analysis_complete", False
+):
+    context.config["use_chunked_processing"] = True
+    return context
+
+df, rename_map = load_optimized_dataframe(...)
+context.current_dataframe = df
+context.column_rename_map = rename_map
+```
+
+- [x] Add `ChunkedAnalysisStage._handle_checkpoint_skip()`:
+
+```python
+def _handle_checkpoint_skip(self, context: PipelineContext) -> PipelineContext:
+    chunked_tsv = context.chunked_analysis_tsv
+    if not chunked_tsv:
+        base = context.workspace.get_intermediate_path("chunked_analysis_results.tsv")
+        gz = Path(str(base) + ".gz")
+        chunked_tsv = gz if gz.exists() else base
+
+    if not chunked_tsv or not Path(chunked_tsv).exists():
+        raise RuntimeError(
+            "Cannot restore chunked_analysis from checkpoint: "
+            f"chunked output missing: {chunked_tsv}"
+        )
+
+    compression = "gzip" if str(chunked_tsv).endswith(".gz") else None
+    df, rename_map = load_optimized_dataframe(
+        str(chunked_tsv),
+        sep="\t",
+        compression=compression,
+        on_bad_lines="warn",
+    )
+    context.current_dataframe = df
+    context.column_rename_map = rename_map
+    context.chunked_analysis_tsv = Path(chunked_tsv)
+    context.config["dataframe_chunked_analysis_complete"] = True
+    context.config["use_chunked_processing"] = True
+    return context
+```
+
+- [x] Ensure `ChunkedAnalysisStage._process()` writes
+  `chunked_analysis_results.tsv(.gz)` even when all chunks are empty but a header is
+  known. If no chunks are processed at all due to missing input, raise instead of warning
+  and returning.
+- [x] Run:
+
+```bash
+pytest tests/unit/stages/test_analysis_stages.py -q
+```
+
+---
+
+## Task 7: Prove Missing-State Failures And Empty Outputs
+
+**Files:**
+- Modify `tests/unit/test_association_stage.py`
+- Modify `tests/unit/test_gene_burden_regression.py` or a focused stage test
+- Modify `tests/unit/stages/test_output_stages.py`
+
+- [x] Add `test_association_requested_without_dataframe_raises`.
+
+Make this assert the error occurs before `AssociationEngine.from_names()` is called.
+
+- [x] Add `test_association_empty_dataframe_writes_header_only_output`.
+- [x] Add `test_gene_burden_requested_without_dataframe_raises`.
+- [x] Add `test_gene_burden_empty_dataframe_writes_header_only_output`.
+- [x] Add `test_statistics_enabled_without_dataframe_raises`.
+- [x] Add `test_tsv_output_without_dataframe_or_chunked_output_raises`.
+- [x] Add `test_excel_requested_without_tsv_raises`.
+- [x] Run and confirm failures:
+
+```bash
+pytest tests/unit/test_association_stage.py tests/unit/test_gene_burden_regression.py tests/unit/stages/test_output_stages.py -q
+```
+
+---
+
+## Task 8: Implement Required Input Contracts And Empty Outputs
+
+**Files:**
+- Modify `variantcentrifuge/stages/analysis_stages.py`
+- Modify `variantcentrifuge/stages/output_stages.py`
+
+- [x] Move the association DataFrame lookup before engine construction:
+
+```python
+df = context.current_dataframe if context.current_dataframe is not None else context.variants_df
+if df is None:
+    raise RuntimeError("No DataFrame loaded for association analysis")
+```
+
+- [x] In association, keep `df.empty` valid and write an empty output:
+
+```python
+if df.empty:
+    assoc_output, compression = self._resolve_association_output(context)
+    empty = pd.DataFrame(columns=self._association_output_columns(test_names))
+    empty.to_csv(assoc_output, sep="\t", index=False, compression=compression)
+    context.config["association_output"] = str(assoc_output)
+    context.association_results = empty
+    return context
+```
+
+Use a small helper for `_association_output_columns(test_names)` so tests can pin the
+schema. At minimum include `gene`, `n_cases`, `n_controls`, `n_variants`,
+`primary_test`, `primary_pvalue`, `primary_qvalue`, and `warnings`, plus configured
+test p-value/q-value columns where known.
+
+- [x] In gene burden, distinguish `None` from empty:
+
+```python
+df = context.current_dataframe
+if df is None:
+    raise RuntimeError("No DataFrame loaded for gene burden analysis")
+if df.empty:
+    burden_output, compression = self._resolve_gene_burden_output(context)
+    empty = pd.DataFrame(columns=self._gene_burden_output_columns(context))
+    empty.to_csv(burden_output, sep="\t", index=False, compression=compression)
+    context.config["gene_burden_output"] = str(burden_output)
+    context.gene_burden_results = empty
+    return context
+```
+
+- [x] In statistics, raise only when stats are enabled and `current_dataframe is None`.
+  Empty DataFrames should still compute or write an empty/default statistics file if the
+  stats engine supports that.
+- [x] In `TSVOutputStage`, raise when no DataFrame and no existing
+  `context.chunked_analysis_tsv` can be copied:
+
+```python
+if df is None and not (context.chunked_analysis_tsv and context.chunked_analysis_tsv.exists()):
+    raise RuntimeError("No data to write")
+```
+
+- [x] In `ExcelReportStage`, raise when Excel is requested and `context.final_output_path`
+  is missing or nonexistent.
+- [x] Run focused tests from Task 7.
+
+---
+
+## Task 9: Prove Policy-Aware Plain Resume Clears Persisted State
+
+**Files:**
+- Modify `tests/unit/pipeline/test_runner.py`
+
+- [x] Add `test_plain_resume_reruns_volatile_dataframe_stage`.
+
+Expected:
+
+- restorable `dataframe_loading` skip handler is called
+- volatile `custom_annotation` is not marked complete before execution
+- `checkpoint_state.clear_step_completion("custom_annotation")` is called
+- `custom_annotation` executes
+- downstream `association_analysis` executes after it
+
+- [x] Add `test_completed_volatile_stage_clears_downstream_completion`.
+
+Checkpoint has completed `custom_annotation`, `inheritance_analysis`, and `tsv_output`.
+Expected calls include all three stages. "Ignore in memory" is not sufficient because
+`Stage.__call__()` has its own checkpoint skip gate.
+
+- [x] Add `test_restore_failure_aborts_resume_before_downstream_execution`.
+- [x] Add `test_stage_call_would_skip_if_runner_does_not_clear_checkpoint` as a guard for
+  the dual-skip-gate regression.
+- [x] Run and confirm failures:
+
+```bash
+pytest tests/unit/pipeline/test_runner.py -q
+```
+
+---
+
+## Task 10: Implement Policy-Aware Plain Resume
+
+**Files:**
+- Modify `variantcentrifuge/pipeline_core/stage.py`
+- Modify `variantcentrifuge/pipeline_core/runner.py`
+- Modify stage classes that need explicit policies.
+
+- [x] Add a conservative policy hook:
+
+```python
+class Stage(ABC):
+    @property
+    def checkpoint_resume_policy(self) -> str:
+        return "recompute"
+```
+
+- [x] Mark restorable stages only after handlers exist:
+
+```python
+class DataFrameLoadingStage(Stage):
+    @property
+    def checkpoint_resume_policy(self) -> str:
+        return "restore"
+```
+
+Do the same for setup loaders with valid handlers, `ParallelCompleteProcessingStage`,
+and `ChunkedAnalysisStage`. Leave volatile DataFrame mutators as the default
+`"recompute"`.
+
+- [x] Add helpers in `PipelineRunner`:
+
+```python
+def _ordered_stages(self, stages: list[Stage]) -> list[Stage]:
+    ordered = []
+    for level in self._create_execution_plan(stages):
+        ordered.extend(level)
+    return ordered
+
+def _clear_stage_and_downstream(
+    self, stage_name: str, ordered: list[Stage], checkpoint_state
+) -> None:
+    names = [stage.name for stage in ordered]
+    start = names.index(stage_name)
+    for name in names[start:]:
+        checkpoint_state.clear_step_completion(name)
+```
+
+- [x] Replace the plain `--resume` pre-loop with execution-order logic:
+
+```python
+ordered = self._ordered_stages(stages)
+for stage in ordered:
+    if not context.checkpoint_state.should_skip_step(stage.name):
+        continue
+
+    policy = stage.checkpoint_resume_policy
+    if policy == "restore":
+        if not hasattr(stage, "_handle_checkpoint_skip"):
+            raise RuntimeError(f"Stage '{stage.name}' is restorable but has no skip handler")
+        context = stage._handle_checkpoint_skip(context)
+        context.mark_complete(stage.name)
+    elif policy == "skip":
+        context.mark_complete(stage.name)
+    else:
+        self._clear_stage_and_downstream(stage.name, ordered, context.checkpoint_state)
+        break
+```
+
+- [x] Avoid repeated stale-stage side effects from `should_skip_step()` where possible.
+  Prefer status helpers for already-cleaned checkpoint state if you add them.
+- [x] Run:
+
+```bash
+pytest tests/unit/pipeline/test_runner.py -q
+```
+
+---
+
+## Task 11: Fix `--resume-from` Restart Semantics
+
+**Files:**
+- Modify `variantcentrifuge/checkpoint.py`
+- Modify `variantcentrifuge/pipeline_core/runner.py`
+- Modify `tests/test_checkpoint.py`
+- Modify `tests/unit/pipeline/test_runner.py`
+
+- [x] Add tests:
+  - `validate_resume_from_stage()` accepts an available stage whose checkpoint status is
+    `failed`
+  - unknown stages still fail
+  - unsafe `--resume-from association_analysis` suggests `--resume-from dataframe_loading`
+  - the hard-coded prerequisite stage set no longer marks policy-recompute stages
+    complete
+
+- [x] Change validation to restart semantics:
+
+```python
+if stage_name not in available_stages:
+    return False, f"Stage '{stage_name}' is not available in current configuration"
+if not self._loaded_from_file:
+    return False, "No checkpoint file loaded"
+return True, ""
+```
+
+Detailed safety belongs in `PipelineRunner`, where the stage graph and policies are
+available.
+
+- [x] In `_handle_selective_resume()`, replace the hard-coded `prerequisite_stages` set
+  with policy-based restoration of ordered prerequisites. If a prerequisite is volatile
+  and is not being re-executed, raise with the nearest safe earlier stage.
+- [x] Run:
+
+```bash
+pytest tests/test_checkpoint.py tests/unit/pipeline/test_runner.py -q
+```
+
+---
+
+## Task 12: Add Output Tracking And Final Validation
+
+**Files:**
+- Modify `variantcentrifuge/stages/output_stages.py`
+- Modify `variantcentrifuge/pipeline.py`
+- Add focused tests in existing output/pipeline test files.
+
+- [x] Add `get_output_files()` to output stages that currently lack it:
+
+```python
+class TSVOutputStage(Stage):
+    def get_output_files(self, context):
+        return [context.final_output_path] if context.final_output_path else []
+
+class ExcelReportStage(Stage):
+    def get_output_files(self, context):
+        path = context.report_paths.get("excel")
+        return [path] if path else []
+
+class MetadataGenerationStage(Stage):
+    def get_output_files(self, context):
+        path = context.report_paths.get("metadata")
+        return [path] if path else []
+```
+
+- [x] Add a final validator in `pipeline.py`:
+
+```python
+def _validate_requested_outputs(context: PipelineContext) -> None:
+    output_file = context.config.get("output_file")
+    if output_file not in (None, "stdout", "-"):
+        if not context.final_output_path or not context.final_output_path.exists():
+            raise RuntimeError("Requested TSV output was not written")
+
+    if context.config.get("perform_association"):
+        assoc = context.config.get("association_output")
+        if not assoc or not Path(assoc).exists():
+            raise RuntimeError("Requested association output was not written")
+
+    if context.config.get("perform_gene_burden"):
+        burden = context.config.get("gene_burden_output")
+        if not burden or not Path(burden).exists():
+            raise RuntimeError("Requested gene burden output was not written")
+
+    if context.config.get("xlsx") or context.config.get("excel"):
+        excel = context.report_paths.get("excel")
+        if not excel or not Path(excel).exists():
+            raise RuntimeError("Requested Excel output was not written")
+```
+
+- [x] Call the validator after `runner.run(stages, context)` and before
+  `logger.info("Pipeline completed successfully!")`.
+- [x] Add tests for missing TSV, association, gene burden, and Excel outputs.
+
+---
+
+## Task 13: Update Resume Documentation
+
+**Files:**
+- Modify `docs/source/resume_system.md`
+
+- [x] Document durable file, restorable memory, and volatile memory resume policies.
+- [x] State that volatile memory stages are re-run after process restart.
+- [x] Document that recompute stages must have checkpoint completion cleared because
+  both the runner and `Stage.__call__()` can skip completed checkpoint stages.
+- [x] Document that missing required checkpoint artifacts abort resume.
+- [x] Update `--resume-from` docs to explain failed-stage recovery and suggested earlier
+  safe stages.
+- [x] Note that `finalizing` stale cleanup should be treated like `running` or explain
+  why it is not.
+- [x] State clearly that after this fix, the AGDE reproduction may correctly fail again
+  in `association_analysis` until the separate categorical genotype bug is fixed.
+
+---
+
+## Task 14: Add Issue #101 Chunked Regression
+
+**Files:**
+- Add `tests/integration/test_checkpoint_resume_state_restoration.py`
+
+- [x] Build a small mock-stage integration that matches the issue shape:
+  - durable TSV-producing stage completed
+  - `dataframe_loading` completed but deferred to chunked analysis
+  - `chunked_analysis` completed and wrote a chunked TSV
+  - volatile DataFrame stage completed
+  - `association_analysis` failed or stale
+
+- [x] On plain resume:
+  - assert the chunked artifact is loaded
+  - assert `context.current_dataframe is not None` before association executes
+  - assert volatile DataFrame stages re-run
+  - assert final TSV and association sidecar exist for success cases
+
+- [x] Add a missing-artifact variant:
+  - remove the chunked TSV
+  - resume must raise
+  - log must not contain `Pipeline completed successfully!`
+
+- [x] Add a zero-row variant:
+  - chunked TSV contains only a header
+  - resume restores an empty DataFrame
+  - TSV and requested sidecars are written as header-only files
+
+---
+
+## Task 15: Run Verification
+
+Focused tests:
+
+```bash
+pytest tests/unit/pipeline/test_stage.py -q
+pytest tests/unit/test_parallel_stage_resume.py -q
+pytest tests/unit/stages/test_analysis_stages.py -q
+pytest tests/unit/pipeline/test_runner.py -q
+pytest tests/unit/test_association_stage.py -q
+pytest tests/unit/test_gene_burden_regression.py -q
+pytest tests/unit/stages/test_output_stages.py -q
+pytest tests/test_checkpoint.py -q
+```
+
+Broader affected suites:
+
+```bash
+pytest tests/test_checkpoint.py tests/test_checkpoint_resume.py tests/test_checkpoint_parallel.py tests/test_checkpoint_parallel_resume.py -q
+pytest tests/unit/stages tests/unit/pipeline -q
+```
+
+Full suite if runtime allows:
+
+```bash
+pytest -q
+```
+
+---
+
+## Completion Criteria
+
+- [x] Issue #101 reproduction no longer produces a false successful pipeline.
+- [x] Plain resume restores chunked DataFrame state or aborts before downstream stages.
+- [x] Recompute stages have persisted checkpoint completion cleared before execution.
+- [x] Requested analysis/output stages cannot complete with `current_dataframe=None`.
+- [x] Valid empty DataFrames produce header-only requested outputs.
+- [x] `--resume-from` gives a safe recovery path for failed stages.
+- [x] Resume documentation matches implementation.
+- [x] Focused and broader checkpoint tests pass.

--- a/docs/superpowers/specs/2026-05-16-checkpoint-resume-state-restoration-design.md
+++ b/docs/superpowers/specs/2026-05-16-checkpoint-resume-state-restoration-design.md
@@ -1,0 +1,552 @@
+# Checkpoint Resume State Restoration Design
+
+## Problem
+
+GitHub issue #101 reports that `--resume` can report a successful pipeline after a
+previous failure even though the resumed process did not restore the in-memory
+DataFrame or produce the requested result files.
+
+Observed run shape:
+
+```text
+initial run:
+  completed through inheritance_analysis
+  association_analysis failed
+
+resume:
+  stale association_analysis marked for re-execution
+  completed upstream stages skipped
+  association_analysis completed in ~1s
+  tsv_output completed in 0s
+  excel_report warned about missing input
+  Pipeline completed successfully
+```
+
+The output directory then contained metadata, logs, and checkpoint files, but no valid
+final `variants.tsv` or association result table.
+
+This is a data integrity bug. A successful exit code must mean that requested analyses
+and outputs were actually produced, or that the pipeline intentionally produced valid
+empty outputs.
+
+## Debug Findings
+
+### 1. Resume Skip Happens Before Runtime State Is Restored
+
+`PipelineRunner.run()` handles plain `--resume` by iterating over all stages before
+execution planning:
+
+```python
+for stage in stages:
+    if context.checkpoint_state.should_skip_step(stage.name):
+        context.mark_complete(stage.name)
+        if hasattr(stage, "_handle_checkpoint_skip"):
+            context = stage._handle_checkpoint_skip(context)
+```
+
+This is only safe for stages whose state can be reconstructed from durable artifacts.
+Many completed stages mutate `context.current_dataframe` only in memory and have no
+checkpoint skip handler. This illustrative list includes:
+
+- `custom_annotation`
+- `inheritance_analysis`
+- `variant_analysis`
+- `variant_identifier`
+- `variant_scoring`
+- `final_filtering`
+- `pseudonymization`
+- `clinvar_pm5`
+
+Skipping these stages after a process restart marks them complete without restoring
+their DataFrame mutations. The runner pre-loop is not the only skip gate:
+`Stage.__call__()` independently calls `checkpoint_state.should_skip_step()` before
+executing a stage. Therefore a policy-aware runner must also clear persisted checkpoint
+completion for any stage that must be recomputed; leaving the checkpoint entry completed
+will still cause `Stage.__call__()` to skip it.
+
+### 2. The Resume Documentation Promises State Restoration
+
+`docs/source/resume_system.md` says memory-based stages should restore state from disk
+when skipped and that `_handle_checkpoint_skip()` is the stage integration point. The
+current implementation only partially follows that contract.
+
+The practical rule should be:
+
+- a completed stage may be skipped only if all context state needed by downstream stages
+  is restored, or
+- the stage must be re-executed, or
+- resume must fail with a clear instruction.
+
+### 3. Some Skip Handlers Are Permissive On Missing Artifacts
+
+`ParallelCompleteProcessingStage._handle_checkpoint_skip()` reconstructs the expected
+merged TSV path and logs a warning if it is missing or invalid, but still assigns that
+path to `context.extracted_tsv`, marks constituent stages complete, and returns.
+
+It also does not restore `context.config["chunked_processing_complete"] = True`, even
+though normal `_process()` sets that flag. Without it, `DataFrameLoadingStage` can enter
+chunked mode during checkpoint skip and avoid loading `context.current_dataframe`.
+
+The issue #101 log also shows `chunked_analysis` being skipped. That matters because
+`DataFrameLoadingStage._handle_checkpoint_skip()` deliberately returns without loading a
+DataFrame when the input should be processed by `ChunkedAnalysisStage`. A correct fix for
+the observed path must restore `chunked_analysis` output or re-run it; restoring only
+`dataframe_loading` is insufficient.
+
+The current `chunked_processing_complete` flag is overloaded:
+`ParallelCompleteProcessingStage` sets it after VCF chunk extraction/merge, and
+`ChunkedAnalysisStage` sets it after DataFrame chunk analysis. These are different
+milestones. Reusing one flag can mask missing `chunked_analysis` state by forcing
+`DataFrameLoadingStage` down a full-load path.
+
+`GenotypeReplacementStage` is currently a universal no-op after Phase 11. Its skip
+handler warning about a missing `genotype_replaced.tsv` is misleading and should become
+a clean no-op skip, not a fatal artifact check. `PhenotypeIntegrationStage` is
+conditionally no-op when no phenotype data is loaded; it should only require an output
+artifact when it actually produced phenotype-integrated TSV state.
+
+### 4. Requested Analysis Stages Can Complete With No DataFrame
+
+Several stages log an error or warning and return `context` instead of failing when their
+required runtime state is missing:
+
+- `AssociationAnalysisStage`: `No DataFrame loaded for association analysis`
+- `GeneBurdenAnalysisStage`: `No DataFrame loaded for gene burden analysis`
+- `StatisticsGenerationStage`: `No DataFrame loaded for statistics`
+- `TSVOutputStage`: `No data to write`
+- `ExcelReportStage`: `No input file for Excel generation`
+
+The stage wrapper marks any returned context as successful and completes the checkpoint.
+That turns a broken resume into completed `association_analysis`, `tsv_output`, and
+`excel_report` entries.
+
+Important distinction:
+
+- `context.current_dataframe is None` means runtime state is missing and should fail for
+  stages that require a DataFrame.
+- `context.current_dataframe.empty` can be a valid zero-variant result and should produce
+  valid header-only outputs where applicable.
+
+Current empty-DataFrame handling is inconsistent with that goal. `AssociationAnalysisStage`
+and `GeneBurdenAnalysisStage` return without writing sidecar output when `df.empty`, and
+`ChunkedAnalysisStage` only writes `chunked_analysis_results.tsv(.gz)` when at least one
+chunk object is returned. Top-level output validation would turn those valid empty runs
+into false failures unless the empty-output paths write header-only artifacts.
+
+### 5. Stage Failures Are Not Recorded By The Stage Wrapper
+
+The `checkpoint()` decorator and `CheckpointContext` context manager call
+`PipelineState.fail_step()` on exceptions. `Stage.__call__()` starts and completes
+checkpoint entries but its exception path only logs and re-raises. The failed stage is
+left as `running`, later detected as stale.
+
+Stale cleanup prevents some partial-output reuse, but it loses the original failure
+status and error message. The wrapper should record failures directly. Because stages can
+run under `ThreadPoolExecutor`, `PipelineState.fail_step()` must be protected by the same
+state lock used by `start_step()` and `complete_step()` before `Stage.__call__()` starts
+calling it from concurrent stage wrappers.
+
+### 6. `--resume-from` Semantics Contradict The Docs
+
+The docs describe `--resume-from STAGE` as restart behavior:
+
+```text
+Restart from specific stage (re-execute stage and all subsequent stages)
+```
+
+`PipelineState.validate_resume_from_stage()` currently rejects a target stage unless
+that target was completed. That blocks the natural recovery command for a failed stage:
+
+```text
+Cannot resume from 'association_analysis':
+Stage 'association_analysis' was not completed in previous run.
+Cannot resume from an incomplete stage.
+```
+
+The direct target may still be unsafe if prerequisite in-memory state cannot be restored.
+The CLI should either rewind to a safe durable stage or refuse with the exact safe
+`--resume-from` stage to use.
+
+## Goals
+
+- Never report pipeline success when requested final outputs are missing.
+- Never mark a requested analysis or output stage complete when its required input state
+  is absent.
+- Make checkpoint skip behavior explicit: skip only durable or restorable stages.
+- Re-execute volatile in-memory stages after resume unless their post-stage state has a
+  durable checkpoint artifact.
+- Restore chunked DataFrame analysis state when a previous run used chunked analysis.
+- Preserve the ability to skip expensive VCF extraction/filtering/chunk processing when
+  their outputs are valid.
+- Improve `--resume-from` so failed-stage recovery has a safe, understandable path.
+- Update tests and docs so future stages follow the same checkpoint contract.
+
+## Non-Goals
+
+- Do not fix the original association categorical error from the first run in this
+  issue. That is a separate analysis bug.
+- Do not serialize the entire `PipelineContext` object as a quick fix.
+- Do not change biological analysis semantics.
+- Do not require every no-op disabled stage to write an output file.
+- Do not make `GenotypeReplacementStage` resume fail for its intentionally missing
+  Phase-11 output file.
+
+## Resume Model
+
+Introduce an explicit checkpoint resume policy for stages.
+
+### Durable File Stage
+
+A stage is safe to skip when all downstream-needed state can be restored from files.
+
+Examples:
+
+- `parallel_complete_processing`
+- `variant_extraction`
+- `field_extraction`
+- `phenotype_integration` when it produced a TSV
+
+Requirements:
+
+- checkpoint output files must exist and validate
+- skip handler must restore context paths and flags
+- missing expected artifacts must raise a resume error, not warn and continue
+
+### Restorable Memory Stage
+
+A memory stage is safe to skip only if it can rebuild the runtime object from a durable
+artifact.
+
+Examples:
+
+- `dataframe_loading` can reload `context.current_dataframe` from the latest TSV
+- `chunked_analysis` can reload from `chunked_analysis_tsv` if that file exists
+
+Requirements:
+
+- skip handler must set the exact runtime state downstream stages need
+- `None` DataFrame after the handler is a hard failure unless the next stages do not need
+  a DataFrame
+
+### Volatile Memory Stage
+
+A stage that mutates in-memory data without a durable post-stage artifact is not safe to
+skip after process restart.
+
+Examples:
+
+- `custom_annotation`
+- `inheritance_analysis`
+- `variant_analysis`
+- `variant_identifier`
+- `variant_scoring`
+- `final_filtering`
+- `pseudonymization`
+- `clinvar_pm5`
+
+Default behavior:
+
+- plain `--resume` should clear completion for the earliest completed volatile stage
+  after the last restored durable state, then re-run that stage and all affected
+  downstream stages
+- selective `--resume-from` should reject or rewind when the target depends on volatile
+  state that cannot be restored
+
+This may re-run cheap DataFrame stages, but it avoids silent data loss.
+
+## Proposed Design
+
+### 1. Add Stage Resume Policy
+
+Add a small API to `Stage`:
+
+```python
+class Stage(ABC):
+    checkpoint_resume_policy = "recompute"
+```
+
+Allowed values:
+
+- `"skip"`: safe to skip without a custom handler because it has no runtime state needed
+  downstream
+- `"restore"`: safe to skip only by calling `_handle_checkpoint_skip()`
+- `"recompute"`: do not skip after restart; re-run even if checkpoint says completed
+
+Prefer conservative defaults. `recompute` is the safest default for stages that do not
+declare a policy.
+
+For the first fix, mark known setup and durable/restorable stages explicitly:
+
+- setup loaders with working skip handlers: `"restore"`
+- `parallel_complete_processing`: `"restore"`
+- `dataframe_loading`: `"restore"`
+- `chunked_analysis`: `"restore"` after its handler exists
+- disabled/no-op report stages can use `"skip"` only when the feature is disabled
+- volatile DataFrame mutators: `"recompute"`
+
+The dual-state invariant is mandatory:
+
+- restored stages: call the skip handler, restore context, mark the stage complete in
+  the in-memory `PipelineContext`, and leave the checkpoint entry completed
+- recompute stages: do not mark the stage complete in memory, and call
+  `clear_step_completion()` for that stage and every downstream stage so
+  `Stage.__call__()` cannot skip them through its own checkpoint gate
+
+### 2. Change Plain Resume Planning
+
+Instead of blindly marking every completed checkpoint stage as complete:
+
+1. Load and validate checkpoint state.
+2. Build the execution order.
+3. Walk completed stages in execution order.
+4. For `"restore"` stages:
+   - call `_handle_checkpoint_skip()`
+   - require it to leave the needed context state valid
+   - mark complete only after restoration succeeds
+5. For `"skip"` stages:
+   - mark complete only when the stage is truly disabled or has no downstream state
+6. For `"recompute"` stages:
+   - clear that stage and every downstream stage from the checkpoint and save the change
+   - stop pre-marking later completed stages
+   - let normal execution re-run from that point
+
+This creates the desired behavior for issue #101:
+
+```text
+restore parallel_complete_processing
+-> restore dataframe_loading if it loaded a DataFrame
+-> restore or re-run chunked_analysis if dataframe_loading deferred to chunking
+-> re-run custom_annotation/inheritance/association/tsv/excel as needed
+```
+
+Because the original AGDE run failed inside `association_analysis`, the first corrected
+resume may fail there again with the original categorical genotype bug. That is the
+right outcome for issue #101: a real failure must stay visible instead of becoming a
+false successful pipeline.
+
+### 2a. Split Chunked Completion State
+
+Replace the overloaded `chunked_processing_complete` meaning with two explicit flags:
+
+```python
+context.config["parallel_vcf_processing_complete"] = True
+context.config["dataframe_chunked_analysis_complete"] = True
+```
+
+`ParallelCompleteProcessingStage` owns `parallel_vcf_processing_complete`.
+`ChunkedAnalysisStage` owns `dataframe_chunked_analysis_complete`. For backward
+compatibility during migration, read the legacy `chunked_processing_complete` only as a
+fallback when neither explicit flag is present; do not let the parallel VCF flag suppress
+DataFrame chunking. `DataFrameLoadingStage` should decide whether to defer to
+`ChunkedAnalysisStage` based on file size and `dataframe_chunked_analysis_complete`, not
+on the parallel VCF processing flag.
+
+### 3. Harden Skip Handlers
+
+`ParallelCompleteProcessingStage._handle_checkpoint_skip()`:
+
+- validate merged TSV before assigning it to context
+- raise if the expected merged TSV is absent or invalid
+- restore:
+
+```python
+context.extracted_tsv = merged_tsv
+context.data = merged_tsv
+context.config["parallel_vcf_processing_complete"] = True
+```
+
+- mark constituent stages complete only after validation succeeds
+
+`DataFrameLoadingStage._handle_checkpoint_skip()`:
+
+- raise if no TSV can be found
+- raise if a TSV path exists but cannot be loaded
+- if it chooses full loading, require `context.current_dataframe is not None`
+- if it intentionally defers to chunked analysis, set `context.config["use_chunked_processing"]`
+  and require a later `ChunkedAnalysisStage` restore or recompute before analysis/output
+  stages run
+
+`ChunkedAnalysisStage._handle_checkpoint_skip()`:
+
+- find `context.chunked_analysis_tsv` or the default
+  `chunked_analysis_results.tsv(.gz)`
+- load it into `context.current_dataframe`
+- set `context.config["dataframe_chunked_analysis_complete"] = True`
+- set `context.chunked_analysis_tsv`
+- if the prior chunked run legitimately produced zero rows, load or write a valid
+  header-only artifact rather than treating missing data rows as corruption
+
+`GenotypeReplacementStage` and `PhenotypeIntegrationStage`:
+
+- `GenotypeReplacementStage` is a Phase-11 no-op and should skip cleanly without looking
+  for `genotype_replaced.tsv`
+- if `PhenotypeIntegrationStage` was a true no-op in this configuration, skip cleanly
+- if the checkpoint says it produced a file and that file is missing, raise
+
+### 4. Make Missing Required Inputs Fatal
+
+Replace warning-and-return behavior with explicit errors when the feature is requested
+and the required input state is missing.
+
+Required hard failures:
+
+- `AssociationAnalysisStage`: `perform_association=True` and no DataFrame
+- `GeneBurdenAnalysisStage`: `perform_gene_burden=True` and no DataFrame
+- `StatisticsGenerationStage`: stats enabled and no DataFrame
+- `TSVOutputStage`: no DataFrame and no valid chunked output file
+- `ExcelReportStage`: Excel requested and final TSV path is missing
+
+Keep zero-row DataFrames valid. They should result in valid empty/header-only output
+files instead of `None` state.
+
+For `GeneBurdenAnalysisStage`, an empty-but-present DataFrame should still resolve and
+store `gene_burden_output`, set `context.gene_burden_results` to an empty DataFrame with
+the normal output schema, and write that header. For `AssociationAnalysisStage`, an
+empty-but-present DataFrame should resolve and store `association_output`, set
+`context.association_results` to an empty DataFrame with the configured association
+schema, and write that header. The missing-DataFrame check in association must happen
+before `AssociationEngine.from_names()` so the error explains the resume-state problem
+instead of surfacing an unrelated backend/dependency error.
+
+### 5. Record Stage Failures In Checkpoint State
+
+Update `Stage.__call__()` exception handling:
+
+```python
+except Exception as e:
+    if context.checkpoint_state:
+        context.checkpoint_state.fail_step(self.name, str(e))
+    logger.error(...)
+    raise
+```
+
+This aligns stage execution with the existing decorator and context-manager checkpoint
+behavior.
+
+`PipelineState.fail_step()` should also take `_state_lock`, matching `start_step()` and
+`complete_step()`. Process-pool execution remains a separate limitation: checkpoint
+mutations made in a child process do not automatically update the parent state, so
+checkpoint-relevant stages should either run in the parent/thread executor or return
+their checkpoint updates for parent-side persistence.
+
+### 6. Fix `--resume-from`
+
+Make the validation match documented restart semantics:
+
+- the stage must exist in the current pipeline
+- the target may be completed, failed, stale, finalizing, or pending
+- at least one valid prior durable/restorable checkpoint must exist when dependencies
+  are not being re-executed
+- the new policy system must replace the hard-coded prerequisite stage name set in
+  `_handle_selective_resume()`; two independent mechanisms will drift
+
+When a requested target cannot safely run because prerequisite in-memory state is not
+restorable, fail with an actionable message:
+
+```text
+Cannot resume from 'association_analysis' safely because required DataFrame state from
+'inheritance_analysis' is not durable. Resume from 'dataframe_loading' to reload the TSV
+and re-run in-memory analysis stages.
+```
+
+An alternative acceptable implementation is automatic rewind:
+
+```text
+Requested --resume-from association_analysis, but the nearest safe restart point is
+dataframe_loading. Re-running from dataframe_loading.
+```
+
+Failing with a suggestion is less surprising for a first fix.
+
+### 7. Add Final Output Validation
+
+After `runner.run(stages, context)` and before logging successful completion:
+
+- if `output_file` is not stdout, require `context.final_output_path` exists
+- if `perform_association`, require `context.config["association_output"]` exists after
+  association completed
+- if `perform_gene_burden`, require `context.config["gene_burden_output"]` exists after
+  gene burden completed
+- if Excel requested, require the Excel report path exists
+
+This is a last-resort guard. The stage contracts should catch the issue earlier, but the
+top-level success log should not rely only on per-stage optimism.
+
+## Acceptance Criteria
+
+- Reproducing issue #101 no longer logs `Pipeline completed successfully` unless the
+  final TSV and requested association output exist.
+- Plain `--resume` after a failed `association_analysis` restores or re-runs the
+  DataFrame-producing path before association executes.
+- `association_analysis`, `tsv_output`, and `excel_report` cannot be checkpoint-completed
+  when their required inputs are missing.
+- Stale or failed stages are recorded as failed in checkpoint state with the original
+  error message.
+- `--resume-from association_analysis` either works safely or fails with the exact earlier
+  stage to use.
+- Existing valid checkpoint resumes for expensive extraction/filtering stages still skip
+  expensive work when outputs validate.
+- Valid zero-variant runs produce header-only final, association, and gene-burden
+  outputs where those outputs were requested.
+- The overloaded `chunked_processing_complete` flag no longer controls both parallel VCF
+  processing and DataFrame chunked analysis.
+
+## Test Strategy
+
+- Unit tests for `Stage.__call__()` failure checkpoint recording.
+- Unit tests for `ParallelCompleteProcessingStage._handle_checkpoint_skip()`:
+  - valid merged TSV restores path and `parallel_vcf_processing_complete`
+  - missing or invalid merged TSV raises
+- Unit tests for `DataFrameLoadingStage._handle_checkpoint_skip()`:
+  - valid TSV reloads DataFrame
+  - missing TSV raises
+  - large/deferred TSV sets `use_chunked_processing` without pretending the DataFrame is
+    restored
+- Unit tests for `ChunkedAnalysisStage._handle_checkpoint_skip()`:
+  - valid chunked output reloads DataFrame and flags
+  - header-only chunked output restores an empty DataFrame
+- Unit tests for required input guards:
+  - association requested plus `current_dataframe=None` raises
+  - association requested plus an empty DataFrame writes a header-only output
+  - gene burden requested plus an empty DataFrame writes a header-only output
+  - TSV output with no DataFrame and no chunked result raises
+  - Excel requested plus missing final TSV raises
+- Runner resume tests:
+  - plain resume does not skip volatile completed DataFrame stages
+  - completed volatile stage causes its own and downstream checkpoint completion to be
+    cleared persistently before `Stage.__call__()` can run
+  - restore failures abort resume before downstream stages can run
+- Flag-split tests:
+  - parallel VCF resume restoration does not suppress DataFrame chunking by itself
+  - DataFrame chunked analysis completion is represented by
+    `dataframe_chunked_analysis_complete`
+- Selective resume tests:
+  - incomplete failed target is accepted only when prerequisites are safely restored
+  - unsafe target emits the suggested earlier stage
+- Integration regression:
+  - create a checkpoint with upstream stages completed and `association_analysis`
+    stale/failed
+  - include the actual issue #101 shape where `dataframe_loading` deferred to
+    `chunked_analysis`
+  - resume
+  - assert `context.current_dataframe` is restored before association executes
+  - assert the pipeline exits non-zero if DataFrame restoration is impossible, or
+    produces final TSV plus association output if restoration succeeds
+
+## Risks
+
+- Re-running volatile DataFrame stages may add minutes to some resumes, but it is safer
+  than trusting stale in-memory state that no longer exists.
+- A more scalable future design would make expensive volatile stages such as
+  `inheritance_analysis` persist their post-stage DataFrame and become restorable. The
+  recompute policy is the minimal correctness fix, not the final performance design.
+- Some tests currently expect warning-and-return behavior for missing data. Those tests
+  should be updated to distinguish disabled/no-op stages from requested stages with
+  broken inputs.
+- Splitting `chunked_processing_complete` touches several guard branches in analysis and
+  output stages. Keep a legacy fallback during migration, but make tests assert the new
+  explicit flag semantics.
+- File-producing stages without skip handlers may need follow-up hardening. The first
+  fix should cover the issue #101 path and add the policy framework so gaps are visible.
+- `cleanup_stale_stages()` currently considers `running` stale but not `finalizing`.
+  Include `finalizing` in the hardening pass or document why it remains separate.

--- a/tests/integration/test_checkpoint_resume_state_restoration.py
+++ b/tests/integration/test_checkpoint_resume_state_restoration.py
@@ -1,0 +1,165 @@
+"""Regression tests for checkpoint resume state restoration."""
+
+from argparse import Namespace
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from variantcentrifuge.checkpoint import PipelineState
+from variantcentrifuge.pipeline_core.context import PipelineContext
+from variantcentrifuge.pipeline_core.runner import PipelineRunner
+from variantcentrifuge.pipeline_core.stage import Stage
+from variantcentrifuge.pipeline_core.workspace import Workspace
+from variantcentrifuge.stages.analysis_stages import ChunkedAnalysisStage, DataFrameLoadingStage
+
+
+class VolatileAnnotationStage(Stage):
+    @property
+    def name(self) -> str:
+        return "custom_annotation"
+
+    @property
+    def dependencies(self) -> set[str]:
+        return {"dataframe_loading"}
+
+    @property
+    def soft_dependencies(self) -> set[str]:
+        return {"chunked_analysis"}
+
+    def _process(self, context: PipelineContext) -> PipelineContext:
+        assert context.current_dataframe is not None
+        context.current_dataframe["RESTORED_MARKER"] = "yes"
+        return context
+
+
+class AssociationProbeStage(Stage):
+    def __init__(self, output_name: str = "association.tsv"):
+        super().__init__()
+        self.saw_dataframe = False
+        self.output_name = output_name
+
+    @property
+    def name(self) -> str:
+        return "association_analysis"
+
+    @property
+    def dependencies(self) -> set[str]:
+        return {"dataframe_loading", "custom_annotation"}
+
+    def _process(self, context: PipelineContext) -> PipelineContext:
+        assert context.current_dataframe is not None
+        assert "RESTORED_MARKER" in context.current_dataframe.columns
+        self.saw_dataframe = True
+        assoc_output = context.workspace.output_dir / self.output_name
+        pd.DataFrame(columns=["gene", "primary_pvalue"]).to_csv(assoc_output, sep="\t", index=False)
+        context.config["association_output"] = str(assoc_output)
+        return context
+
+
+class FinalTSVStage(Stage):
+    @property
+    def name(self) -> str:
+        return "tsv_output"
+
+    @property
+    def dependencies(self) -> set[str]:
+        return {"association_analysis"}
+
+    def _process(self, context: PipelineContext) -> PipelineContext:
+        assert context.current_dataframe is not None
+        output = context.workspace.output_dir / "variants.tsv"
+        context.current_dataframe.to_csv(output, sep="\t", index=False)
+        context.final_output_path = output
+        return context
+
+
+def _context_with_state(tmp_path: Path, chunked_text: str | None) -> PipelineContext:
+    workspace = Workspace(tmp_path, "resume_case")
+    workspace.intermediate_dir.mkdir(parents=True, exist_ok=True)
+    extracted = workspace.intermediate_dir / "resume_case.extracted.tsv"
+    extracted.write_text("GENE\tCHROM\nBRCA1\tchr1\n")
+    if chunked_text is not None:
+        (workspace.intermediate_dir / "chunked_analysis_results.tsv").write_text(chunked_text)
+
+    config = {
+        "resume": True,
+        "pipeline_version": "test-version",
+        "output_file": "variants.tsv",
+        "perform_association": True,
+        "gzip_intermediates": False,
+        "force_chunked_processing": True,
+    }
+    state = PipelineState(str(tmp_path), enable_checksum=False)
+    state.initialize(config, "test-version")
+    for name in [
+        "dataframe_loading",
+        "chunked_analysis",
+        "custom_annotation",
+        "association_analysis",
+        "tsv_output",
+    ]:
+        state.start_step(name)
+        state.complete_step(name, [], [])
+
+    resume_state = PipelineState(str(tmp_path), enable_checksum=False)
+    assert resume_state.load()
+    context = PipelineContext(args=Namespace(), config=config, workspace=workspace)
+    context.data = extracted
+    context.extracted_tsv = extracted
+    context.checkpoint_state = resume_state
+    return context
+
+
+def test_plain_resume_restores_chunked_dataframe_before_association(tmp_path):
+    """Issue #101 shape: chunked_analysis restore happens before association resumes."""
+    context = _context_with_state(tmp_path, "GENE\tCHROM\nBRCA1\tchr1\n")
+    association = AssociationProbeStage()
+    stages = [
+        DataFrameLoadingStage(),
+        ChunkedAnalysisStage(),
+        VolatileAnnotationStage(),
+        association,
+        FinalTSVStage(),
+    ]
+
+    result = PipelineRunner(enable_checkpoints=True, max_workers=1).run(stages, context)
+
+    assert association.saw_dataframe is True
+    assert result.current_dataframe is not None
+    assert result.final_output_path.exists()
+    assert Path(result.config["association_output"]).exists()
+    assert "RESTORED_MARKER" in result.final_output_path.read_text()
+
+
+def test_plain_resume_aborts_when_chunked_artifact_missing(tmp_path):
+    """Missing chunked analysis artifact must abort resume before downstream success."""
+    context = _context_with_state(tmp_path, None)
+    stages = [
+        DataFrameLoadingStage(),
+        ChunkedAnalysisStage(),
+        VolatileAnnotationStage(),
+        AssociationProbeStage(),
+        FinalTSVStage(),
+    ]
+
+    with pytest.raises(RuntimeError, match="Cannot restore chunked_analysis"):
+        PipelineRunner(enable_checkpoints=True, max_workers=1).run(stages, context)
+
+
+def test_plain_resume_restores_header_only_chunked_dataframe(tmp_path):
+    """Header-only chunked output is a valid empty resumed DataFrame."""
+    context = _context_with_state(tmp_path, "GENE\tCHROM\n")
+    stages = [
+        DataFrameLoadingStage(),
+        ChunkedAnalysisStage(),
+        VolatileAnnotationStage(),
+        AssociationProbeStage(),
+        FinalTSVStage(),
+    ]
+
+    result = PipelineRunner(enable_checkpoints=True, max_workers=1).run(stages, context)
+
+    assert result.current_dataframe is not None
+    assert result.current_dataframe.empty
+    assert result.final_output_path.read_text().startswith("GENE\tCHROM\tRESTORED_MARKER\n")

--- a/tests/unit/pipeline/test_runner.py
+++ b/tests/unit/pipeline/test_runner.py
@@ -281,6 +281,36 @@ class TestPipelineRunner:
         assert any("fast" in call for call in info_calls)
         assert any("slow" in call for call in info_calls)
 
+    def test_selective_resume_rejects_incomplete_prerequisite(self, context):
+        """Selective resume must not skip an incomplete prerequisite stage."""
+        runner = PipelineRunner(enable_checkpoints=True, max_workers=1)
+        context.config = {"resume_from": "target"}
+        checkpoint_state = Mock()
+        checkpoint_state.load.return_value = True
+        checkpoint_state.validate_resume_from_stage.return_value = (True, "")
+        checkpoint_state.should_skip_step.return_value = False
+        context.checkpoint_state = checkpoint_state
+        stages = [
+            MockStage("setup"),
+            MockStage("target", dependencies=["setup"]),
+        ]
+
+        with pytest.raises(ValueError, match="prerequisite stage 'setup' was not completed"):
+            runner.run(stages, context)
+
+    def test_clear_stage_and_downstream_saves_once(self):
+        """Clearing a long checkpoint tail should batch disk persistence."""
+        runner = PipelineRunner()
+        checkpoint_state = Mock()
+        stages = [MockStage("stage1"), MockStage("stage2"), MockStage("stage3")]
+
+        runner._clear_stage_and_downstream("stage2", stages, checkpoint_state)
+
+        assert checkpoint_state.clear_step_completion.call_count == 2
+        checkpoint_state.clear_step_completion.assert_any_call("stage2", save=False)
+        checkpoint_state.clear_step_completion.assert_any_call("stage3", save=False)
+        checkpoint_state.save.assert_called_once()
+
     def test_checkpoint_saving(self, runner, context):
         """Test checkpoint saving during execution."""
         # Enable checkpoints

--- a/tests/unit/pipeline/test_stage.py
+++ b/tests/unit/pipeline/test_stage.py
@@ -130,6 +130,19 @@ class TestStage:
         assert "Stage failed!" in str(exc_info.value)
         context.mark_complete.assert_not_called()
 
+    def test_stage_failure_marks_checkpoint_failed(self, context):
+        """Failing stages should record failure in checkpoint state."""
+        stage = FailingStage()
+        context.checkpoint_state = Mock()
+        context.checkpoint_state.should_skip_step.return_value = False
+
+        with pytest.raises(ValueError, match="Stage failed!"):
+            stage(context)
+
+        context.checkpoint_state.start_step.assert_called_once()
+        context.checkpoint_state.fail_step.assert_called_once_with("failing_stage", "Stage failed!")
+        context.checkpoint_state.complete_step.assert_not_called()
+
     @patch("variantcentrifuge.pipeline_core.stage.logger")
     def test_logging(self, mock_logger, context):
         """Test stage execution logging."""

--- a/tests/unit/stages/test_analysis_stages.py
+++ b/tests/unit/stages/test_analysis_stages.py
@@ -97,6 +97,62 @@ class TestDataFrameLoadingStage:
         assert result.current_dataframe is not None
         assert len(result.current_dataframe) == 1
 
+    def test_parallel_skip_does_not_suppress_dataframe_chunking(self, base_context, tmp_path):
+        """Parallel VCF completion alone should not suppress DataFrame chunking."""
+        test_file = tmp_path / "large.tsv"
+        test_file.write_text("GENE\tCHROM\nBRCA1\tchr1\n")
+        base_context.config = {"parallel_vcf_processing_complete": True}
+        base_context.data = test_file
+
+        stage = DataFrameLoadingStage()
+        with patch.object(stage, "_should_use_chunks", return_value=True):
+            result = stage._handle_checkpoint_skip(base_context)
+
+        assert result.config["use_chunked_processing"] is True
+        assert result.current_dataframe is None
+
+    def test_dataframe_loading_skip_raises_when_no_tsv_available(self, base_context):
+        """Restoring dataframe_loading requires an available TSV artifact."""
+        base_context.data = None
+
+        with pytest.raises(RuntimeError, match="Cannot restore dataframe_loading"):
+            DataFrameLoadingStage()._handle_checkpoint_skip(base_context)
+
+    def test_chunked_analysis_skip_restores_dataframe_from_artifact(self, base_context, tmp_path):
+        """Chunked analysis skip restores the DataFrame from its durable artifact."""
+        chunked_tsv = tmp_path / "chunked.tsv"
+        chunked_tsv.write_text("GENE\tCHROM\nBRCA1\tchr1\n")
+        base_context.chunked_analysis_tsv = chunked_tsv
+
+        result = ChunkedAnalysisStage()._handle_checkpoint_skip(base_context)
+
+        assert result.current_dataframe is not None
+        assert len(result.current_dataframe) == 1
+        assert result.chunked_analysis_tsv == chunked_tsv
+        assert result.config["dataframe_chunked_analysis_complete"] is True
+
+    def test_chunked_analysis_skip_restores_header_only_empty_dataframe(
+        self, base_context, tmp_path
+    ):
+        """Header-only chunked artifacts are valid empty results."""
+        chunked_tsv = tmp_path / "chunked.tsv"
+        chunked_tsv.write_text("GENE\tCHROM\n")
+        base_context.chunked_analysis_tsv = chunked_tsv
+
+        result = ChunkedAnalysisStage()._handle_checkpoint_skip(base_context)
+
+        assert result.current_dataframe is not None
+        assert result.current_dataframe.empty
+        assert list(result.current_dataframe.columns) == ["GENE", "CHROM"]
+        assert result.config["dataframe_chunked_analysis_complete"] is True
+
+    def test_chunked_analysis_skip_raises_when_artifact_missing(self, base_context, tmp_path):
+        """Restoring chunked analysis requires its output artifact."""
+        base_context.chunked_analysis_tsv = tmp_path / "missing.tsv"
+
+        with pytest.raises(RuntimeError, match="Cannot restore chunked_analysis"):
+            ChunkedAnalysisStage()._handle_checkpoint_skip(base_context)
+
 
 class TestCustomAnnotationStage:
     """Test the CustomAnnotationStage."""

--- a/tests/unit/stages/test_inheritance_analysis_stage.py
+++ b/tests/unit/stages/test_inheritance_analysis_stage.py
@@ -194,7 +194,7 @@ class TestInheritanceAnalysisStage:
         """Test stage dependencies."""
         stage = InheritanceAnalysisStage()
         assert stage.dependencies == {"dataframe_loading"}
-        assert stage.soft_dependencies == {"custom_annotation"}
+        assert stage.soft_dependencies == {"custom_annotation", "chunked_analysis"}
 
     def test_parallel_safe(self):
         """Test parallel safety."""

--- a/tests/unit/stages/test_output_stages.py
+++ b/tests/unit/stages/test_output_stages.py
@@ -535,22 +535,24 @@ class TestTSVOutputStage:
             assert call_args[1]["na_rep"] == ""
 
     def test_missing_dataframe(self, context):
-        """Test handling when no DataFrame available."""
+        """Missing DataFrame should fail requested TSV output."""
         context.current_dataframe = None
 
         stage = TSVOutputStage()
-        result = stage(context)
 
-        # Should return context without error
-        assert result is context
-        # final_output_path should not be set when there's no data
-        assert result.final_output_path is None
+        with pytest.raises(RuntimeError, match="No data to write"):
+            stage(context)
 
     def test_dependencies(self):
         """Test stage dependencies."""
         stage = TSVOutputStage()
         assert stage.dependencies == {"dataframe_loading", "variant_identifier"}
-        assert stage.soft_dependencies == {"variant_scoring", "final_filtering", "pseudonymization"}
+        assert stage.soft_dependencies == {
+            "variant_scoring",
+            "final_filtering",
+            "pseudonymization",
+            "chunked_analysis",
+        }
 
     def test_tsv_output_drops_raw_gt_columns_when_packed_gt_exists(self, context):
         """Final TSV should not leak raw GEN[N].GT columns by default."""

--- a/tests/unit/stages/test_output_stages_simple.py
+++ b/tests/unit/stages/test_output_stages_simple.py
@@ -144,9 +144,8 @@ class TestTSVOutputStage:
         context.mark_complete("variant_identifier")
 
         stage = TSVOutputStage()
-        # Should log warning and return
-        result = stage(context)
-        assert result == context
+        with pytest.raises(RuntimeError, match="No data to write"):
+            stage(context)
 
 
 class TestMetadataGenerationStage:

--- a/tests/unit/stages/test_setup_stages.py
+++ b/tests/unit/stages/test_setup_stages.py
@@ -129,6 +129,16 @@ class TestPhenotypeLoadingStage:
         # Should return unchanged
         assert result.phenotype_data is None
 
+    @patch("variantcentrifuge.stages.setup_stages.load_phenotypes")
+    def test_checkpoint_skip_raises_when_configured_phenotypes_missing(
+        self, mock_load_phenotypes, context
+    ):
+        """Checkpoint restore should fail if configured phenotypes cannot be loaded."""
+        mock_load_phenotypes.return_value = {}
+
+        with pytest.raises(ValueError, match="No phenotype data loaded"):
+            PhenotypeLoadingStage()._handle_checkpoint_skip(context)
+
     def test_parallel_safe(self):
         """Test parallel safety."""
         stage = PhenotypeLoadingStage()
@@ -168,6 +178,16 @@ class TestScoringConfigLoadingStage:
 
         # Should return unchanged
         assert result.scoring_config is None
+
+    @patch("variantcentrifuge.stages.setup_stages.read_scoring_config")
+    def test_checkpoint_skip_raises_when_scoring_restore_fails(
+        self, mock_read_scoring_config, context
+    ):
+        """Checkpoint restore should not swallow configured scoring load failures."""
+        mock_read_scoring_config.side_effect = OSError("missing scoring config")
+
+        with pytest.raises(ValueError, match="Failed to restore scoring configuration"):
+            ScoringConfigLoadingStage()._handle_checkpoint_skip(context)
 
     def test_parallel_safe(self):
         """Test parallel safety."""
@@ -219,6 +239,14 @@ class TestPedigreeLoadingStage:
 
         # Should return unchanged
         assert result.pedigree_data is None
+
+    @patch("variantcentrifuge.stages.setup_stages.read_pedigree")
+    def test_checkpoint_skip_raises_when_pedigree_restore_fails(self, mock_read_pedigree, context):
+        """Checkpoint restore should not swallow configured pedigree load failures."""
+        mock_read_pedigree.side_effect = OSError("missing pedigree")
+
+        with pytest.raises(ValueError, match="Failed to restore pedigree file"):
+            PedigreeLoadingStage()._handle_checkpoint_skip(context)
 
     def test_parallel_safe(self):
         """Test parallel safety."""
@@ -386,6 +414,13 @@ class TestSampleConfigLoadingStage:
         """Test stage dependencies."""
         stage = SampleConfigLoadingStage()
         assert stage.dependencies == {"configuration_loading"}
+
+    def test_checkpoint_skip_raises_without_vcf_file(self, context):
+        """Checkpoint restore should fail when configured VCF input is absent."""
+        context.config["vcf_file"] = None
+
+        with pytest.raises(ValueError, match="No VCF file specified"):
+            SampleConfigLoadingStage()._handle_checkpoint_skip(context)
 
     @patch("variantcentrifuge.stages.setup_stages.get_vcf_samples")
     def test_remove_sample_substring_basic(self, mock_get_samples, context):
@@ -706,6 +741,13 @@ class TestPhenotypeCaseControlAssignmentStage:
         """Test stage dependencies."""
         stage = PhenotypeCaseControlAssignmentStage()
         assert stage.dependencies == {"phenotype_loading", "sample_config_loading"}
+
+    def test_checkpoint_skip_raises_when_phenotype_assignment_state_missing(self, context):
+        """Checkpoint restore should fail if phenotype assignment inputs are incomplete."""
+        context.vcf_samples = []
+
+        with pytest.raises(ValueError, match="No VCF samples found"):
+            PhenotypeCaseControlAssignmentStage()._handle_checkpoint_skip(context)
 
     def test_parallel_safe(self):
         """Test parallel safety."""

--- a/tests/unit/test_association_genotype_matrix.py
+++ b/tests/unit/test_association_genotype_matrix.py
@@ -235,6 +235,33 @@ class TestBuildGenotypeMatrixBasic:
         assert geno[1, 0] == pytest.approx(1.0)  # 0/1
         assert geno[2, 0] == pytest.approx(2.0)  # 1/1
 
+    def test_build_genotype_matrix_handles_categorical_gt_missing_values(self) -> None:
+        """Categorical GT columns must allow missing values without adding categories."""
+        gene_df = pd.DataFrame(
+            {
+                "GEN_0__GT": pd.Categorical(
+                    ["0/1", None],
+                    categories=["0/0", "0/1", "1/1"],
+                ),
+                "GEN_1__GT": pd.Categorical(
+                    ["0/0", "1/1"],
+                    categories=["0/0", "0/1", "1/1"],
+                ),
+            }
+        )
+
+        geno, _, _, _ = build_genotype_matrix(
+            gene_df,
+            ["SAMPLE_0", "SAMPLE_1"],
+            ["GEN_0__GT", "GEN_1__GT"],
+            is_binary=True,
+            missing_site_threshold=1.0,
+        )
+
+        assert geno.shape == (2, 2)
+        assert not np.isnan(geno).any()
+        assert geno[0, 0] == pytest.approx(1.0)
+
     def test_build_genotype_matrix_maf_computation(self) -> None:
         """MAF computed correctly from observed dosages."""
         # 4 samples: 0/0, 0/1, 0/1, 1/1

--- a/tests/unit/test_association_stage.py
+++ b/tests/unit/test_association_stage.py
@@ -149,7 +149,7 @@ class TestAssociationAnalysisStageSkipBehavior:
         assert result.association_results is None
 
     def test_skips_when_dataframe_is_none(self, mock_workspace):
-        """Stage returns context unchanged when no DataFrame is loaded."""
+        """Requested association fails when no DataFrame is loaded."""
         config = {
             "perform_association": True,
             "case_samples": ["CASE1"],
@@ -158,9 +158,9 @@ class TestAssociationAnalysisStageSkipBehavior:
         context = _make_context(config, None, mock_workspace)
 
         stage = AssociationAnalysisStage()
-        result = stage._process(context)
 
-        assert result.association_results is None
+        with pytest.raises(RuntimeError, match="No DataFrame loaded for association analysis"):
+            stage._process(context)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_parallel_stage_resume.py
+++ b/tests/unit/test_parallel_stage_resume.py
@@ -60,6 +60,7 @@ class TestParallelCompleteProcessingStage:
         context.workspace = Mock()
         context.workspace.base_name = "test"
         context.workspace.intermediate_dir = Path("/tmp")
+        context.config = {}
 
         expected_tsv = Path("/tmp/test.extracted.tsv.gz")
 
@@ -80,6 +81,22 @@ class TestParallelCompleteProcessingStage:
         ]
         actual_calls = [call.args for call in context.mark_complete.call_args_list]
         assert actual_calls == expected_calls
+        assert result.config["parallel_vcf_processing_complete"] is True
+        assert "dataframe_chunked_analysis_complete" not in result.config
+
+    def test_handle_checkpoint_skip_raises_for_missing_merged_tsv(self, tmp_path):
+        """Checkpoint skip should fail when the durable merged TSV is unavailable."""
+        stage = ParallelCompleteProcessingStage()
+        context = Mock(spec=PipelineContext)
+        context.workspace = Mock()
+        context.workspace.base_name = "test"
+        context.workspace.intermediate_dir = tmp_path
+        context.config = {}
+
+        with pytest.raises(RuntimeError, match="Cannot restore parallel_complete_processing"):
+            stage._handle_checkpoint_skip(context)
+
+        context.mark_complete.assert_not_called()
 
     @patch(
         "variantcentrifuge.stages.processing_stages.ParallelCompleteProcessingStage"

--- a/variantcentrifuge/association/genotype_matrix.py
+++ b/variantcentrifuge/association/genotype_matrix.py
@@ -63,8 +63,10 @@ def _vectorized_parse_gt_columns(
     multi_allelic_count = 0
 
     for s_idx, col in enumerate(gt_columns_list):
-        # Get column as string series, normalize separator
-        gt_series = gene_df[col].fillna("./.").astype(str).str.replace("|", "/", regex=False)
+        # Convert before fillna so categorical GT columns do not need "./."
+        # added as an explicit category.
+        gt_series = gene_df[col].astype(object).fillna("./.").astype(str)
+        gt_series = gt_series.str.replace("|", "/", regex=False)
 
         # Standard diploid genotypes — exact match for speed
         m_00 = gt_series == "0/0"

--- a/variantcentrifuge/checkpoint.py
+++ b/variantcentrifuge/checkpoint.py
@@ -604,19 +604,26 @@ class PipelineState:
 
     def fail_step(self, step_name: str, error: str) -> None:
         """Mark a step as failed."""
-        if step_name not in self.state["steps"]:
-            logger.warning(f"Failing unstarted step: {step_name}")
-            self.start_step(step_name)
+        with self._state_lock:
+            if step_name not in self.state["steps"]:
+                logger.warning(f"Failing unstarted step: {step_name}")
+                self.state["steps"][step_name] = StepInfo(
+                    name=step_name,
+                    status="running",
+                    start_time=time.time(),
+                    command_hash=None,
+                    parameters={},
+                )
 
-        step_info = self.state["steps"][step_name]
-        step_info.status = "failed"
-        step_info.end_time = time.time()
-        step_info.error = error
+            step_info = self.state["steps"][step_name]
+            step_info.status = "failed"
+            step_info.end_time = time.time()
+            step_info.error = error
 
         self.save()
         logger.error(f"Step '{step_name}' failed: {error}")
 
-    def clear_step_completion(self, step_name: str) -> None:
+    def clear_step_completion(self, step_name: str, save: bool = True) -> None:
         """Clear completion status for a step to force re-execution.
 
         This method is used for restart functionality where you want to
@@ -626,6 +633,9 @@ class PipelineState:
         ----------
         step_name : str
             Name of the step to clear completion status for
+        save : bool
+            Persist the checkpoint file immediately. Callers clearing many
+            steps can pass ``False`` and save once after the batch.
         """
         if step_name not in self.state["steps"]:
             logger.debug(f"Step '{step_name}' not in checkpoint state, nothing to clear")
@@ -639,7 +649,8 @@ class PipelineState:
             step_info.error = None
             # Keep output files for potential validation but clear the completion status
             logger.debug(f"Cleared completion status for step '{step_name}' (restart mode)")
-            self.save()
+            if save:
+                self.save()
 
     def get_summary(self) -> str:
         """Get a human-readable summary of the pipeline state."""
@@ -723,22 +734,7 @@ class PipelineState:
         if stage_name not in available_stages:
             return False, f"Stage '{stage_name}' is not available in current configuration"
 
-        # Check if we have any completed stages
-        completed_stages = self.get_available_resume_points()
-        if not completed_stages:
-            return False, "No completed stages found in checkpoint"
-
-        # If stage is already completed, it's a valid resume point
-        if stage_name in completed_stages:
-            return True, ""
-
-        # If stage is not completed, check if it makes sense to resume from it
-        # This would mean starting the pipeline from this stage without its dependencies
-        return (
-            False,
-            f"Stage '{stage_name}' was not completed in previous run. "
-            f"Cannot resume from an incomplete stage.",
-        )
+        return True, ""
 
     def get_stages_to_execute(self, resume_from: str, all_stages: list[str]) -> list[str]:
         """Get ordered list of stages to execute when resuming from specific stage.

--- a/variantcentrifuge/pipeline.py
+++ b/variantcentrifuge/pipeline.py
@@ -67,6 +67,30 @@ from .utils import compute_base_name
 logger = logging.getLogger(__name__)
 
 
+def _validate_requested_outputs(context: PipelineContext) -> None:
+    """Ensure requested user-facing outputs exist before reporting success."""
+    output_file = context.config.get("output_file")
+    if output_file not in (None, "stdout", "-") and (
+        not context.final_output_path or not context.final_output_path.exists()
+    ):
+        raise RuntimeError("Requested TSV output was not written")
+
+    if context.config.get("perform_association"):
+        assoc = context.config.get("association_output")
+        if not assoc or not Path(assoc).exists():
+            raise RuntimeError("Requested association output was not written")
+
+    if context.config.get("perform_gene_burden"):
+        burden = context.config.get("gene_burden_output")
+        if not burden or not Path(burden).exists():
+            raise RuntimeError("Requested gene burden output was not written")
+
+    if context.config.get("xlsx") or context.config.get("excel"):
+        excel = context.report_paths.get("excel")
+        if not excel or not Path(excel).exists():
+            raise RuntimeError("Requested Excel output was not written")
+
+
 def check_scoring_requires_inheritance(args: argparse.Namespace, config: dict) -> bool:
     """Check if scoring configuration requires inheritance analysis.
 
@@ -593,7 +617,8 @@ def run_pipeline(args: argparse.Namespace) -> None:
 
     try:
         # Run pipeline
-        runner.run(stages, context)
+        context = runner.run(stages, context)
+        _validate_requested_outputs(context)
 
         logger.info("Pipeline completed successfully!")
 

--- a/variantcentrifuge/pipeline_core/runner.py
+++ b/variantcentrifuge/pipeline_core/runner.py
@@ -121,15 +121,8 @@ class PipelineRunner:
                     logger.info("Resume mode: Checking pipeline state...")
                     logger.info(context.checkpoint_state.get_summary())
 
-                    # Mark completed stages as complete in context
-                    for stage in stages:
-                        if context.checkpoint_state.should_skip_step(stage.name):
-                            logger.info(f"Skipping completed stage: {stage.name}")
-                            context.mark_complete(stage.name)
-
-                            # Handle checkpoint skip logic for composite stages
-                            if hasattr(stage, "_handle_checkpoint_skip"):
-                                context = stage._handle_checkpoint_skip(context)
+                    ordered_stages = self._ordered_stages(stages)
+                    context = self._restore_or_recompute_completed_stages(ordered_stages, context)
 
                     assert context.checkpoint_state is not None
                     resume_point = context.checkpoint_state.get_resume_point()
@@ -200,116 +193,116 @@ class PipelineRunner:
         assert context.checkpoint_state is not None, (
             "checkpoint_state required for selective resume"
         )
+        checkpoint_state = context.checkpoint_state
 
         resume_from = context.config.get("resume_from")
         if not resume_from:
             return stages
 
         # Load checkpoint state
-        if not context.checkpoint_state.load():
+        if not checkpoint_state.load():
             raise ValueError("Cannot resume: No checkpoint file found")
 
         # Validate resume point
         stage_names = [stage.name for stage in stages]
-        is_valid, error_msg = context.checkpoint_state.validate_resume_from_stage(
-            resume_from, stage_names
-        )
+        is_valid, error_msg = checkpoint_state.validate_resume_from_stage(resume_from, stage_names)
 
         if not is_valid:
             raise ValueError(f"Cannot resume from '{resume_from}': {error_msg}")
 
-        # Validate dependencies and get stages to execute
-        stages_to_execute = self._get_stages_to_execute_from(resume_from, stages, context)
+        all_stages_ordered = self._ordered_stages(stages)
+        stage_names_ordered = [stage.name for stage in all_stages_ordered]
+        resume_index = stage_names_ordered.index(resume_from)
 
-        # Restart from specified stage - clear completion status for resume stage and all
-        # subsequent stages
-        completed_stages = context.checkpoint_state.get_available_resume_points()
-        current_stage_names = {stage.name for stage in stages}
-        stage_map = {stage.name: stage for stage in stages}
-
-        # Get all stages in execution order to determine which come before/after resume point
-        execution_plan = self._create_execution_plan(stages)
-        all_stages_ordered = []
-        for level in execution_plan:
-            all_stages_ordered.extend(level)
-
-        # Find the index of the resume stage
-        resume_index = None
-        for i, stage in enumerate(all_stages_ordered):
-            if stage.name == resume_from:
-                resume_index = i
-                break
-
-        if resume_index is None:
-            raise ValueError(f"Could not find resume stage '{resume_from}' in execution plan")
-
-        # Determine stages that come before the resume point (these can stay complete)
-        stages_before_resume = {stage.name for stage in all_stages_ordered[:resume_index]}
+        # Restore only durable/restorable prerequisites. A completed volatile
+        # prerequisite cannot be safely trusted after process restart.
+        safe_restart = None
+        for prior_stage in all_stages_ordered[:resume_index]:
+            if prior_stage.checkpoint_resume_policy in {"restore", "skip"}:
+                safe_restart = prior_stage.name
+            if not checkpoint_state.should_skip_step(prior_stage.name):
+                if context.is_complete(prior_stage.name):
+                    continue
+                raise ValueError(
+                    f"Cannot resume from '{resume_from}' safely because prerequisite "
+                    f"stage '{prior_stage.name}' was not completed in the checkpoint. "
+                    f"Resume from '{prior_stage.name}' or an earlier stage."
+                )
+            if prior_stage.checkpoint_resume_policy == "recompute":
+                suggestion = safe_restart or stage_names_ordered[0]
+                raise ValueError(
+                    f"Cannot resume from '{resume_from}' safely because required "
+                    f"DataFrame state from '{prior_stage.name}' is not durable. "
+                    f"Resume from '{suggestion}' to restore durable inputs and "
+                    "re-run in-memory analysis stages."
+                )
+            context = self._restore_completed_stage(prior_stage, context)
 
         # Clear completion status in checkpoint for restart stage and all subsequent stages
-        stages_to_clear = {stage.name for stage in all_stages_ordered[resume_index:]}
-        for stage_name in stages_to_clear:
-            context.checkpoint_state.clear_step_completion(stage_name)
-
-        logger.info(f"Cleared completion status for {len(stages_to_clear)} stages to force restart")
-
-        # Add prerequisite stages that should be considered complete for restart
-        # These are fundamental setup stages that must have completed for pipeline to reach
-        # this point
-        prerequisite_stages = {
-            "configuration_loading",
-            "sample_config_loading",
-            "gene_bed_creation",
-            "pedigree_loading",
-            "phenotype_loading",
-            "scoring_config_loading",
-            "annotation_config_loading",
-        }
-
-        # Mark prerequisite stages as complete if they exist in the pipeline and come before
-        # resume point
-        for prereq_stage in prerequisite_stages:
-            if prereq_stage in stage_map and prereq_stage in stages_before_resume:
-                logger.debug(f"Marking prerequisite stage as complete for restart: {prereq_stage}")
-                context.mark_complete(prereq_stage)
-
-                # Call checkpoint skip logic to restore context data (VCF samples, configs, etc.)
-                stage_instance = stage_map[prereq_stage]
-                if hasattr(stage_instance, "_handle_checkpoint_skip"):
-                    logger.debug(
-                        f"Calling checkpoint skip logic for prerequisite stage: {prereq_stage}"
-                    )
-                    context = stage_instance._handle_checkpoint_skip(context)
-
-        # Mark only stages that come BEFORE the resume point as complete
-        for completed_stage in completed_stages:
-            if completed_stage in stages_before_resume:
-                # Mark stage as complete in context
-                context.mark_complete(completed_stage)
-
-                # For stages that are in the original stages list (before filtering),
-                # call their checkpoint skip logic to restore virtual dependencies
-                if completed_stage in stage_map:
-                    stage_instance = stage_map[completed_stage]
-                    if hasattr(stage_instance, "_handle_checkpoint_skip"):
-                        logger.debug(
-                            f"Calling checkpoint skip logic for completed stage: {completed_stage}"
-                        )
-                        context = stage_instance._handle_checkpoint_skip(context)
-
-                if completed_stage in current_stage_names:
-                    logger.info(f"Marking completed stage as done: {completed_stage}")
-                else:
-                    logger.debug(f"Marking virtual completed stage as done: {completed_stage}")
-            else:
-                # Stage comes at or after resume point - do not mark as complete (force re-run)
-                logger.debug(f"Stage '{completed_stage}' will be re-run (at or after resume point)")
+        self._clear_stage_and_downstream(resume_from, all_stages_ordered, checkpoint_state)
+        stages_to_execute = all_stages_ordered[resume_index:]
 
         logger.info(
             f"Restart mode: Starting from '{resume_from}' with {len(stages_to_execute)} "
             f"stages to execute"
         )
         return stages_to_execute
+
+    def _ordered_stages(self, stages: list[Stage]) -> list[Stage]:
+        """Return stages flattened in dependency execution order."""
+        ordered: list[Stage] = []
+        for level in self._create_execution_plan(stages):
+            ordered.extend(level)
+        return ordered
+
+    def _clear_stage_and_downstream(
+        self, stage_name: str, ordered: list[Stage], checkpoint_state
+    ) -> None:
+        """Clear persisted completion for a stage and every downstream ordered stage."""
+        names = [stage.name for stage in ordered]
+        start = names.index(stage_name)
+        for name in names[start:]:
+            checkpoint_state.clear_step_completion(name, save=False)
+        checkpoint_state.save()
+
+    def _restore_completed_stage(self, stage: Stage, context: PipelineContext) -> PipelineContext:
+        """Restore or skip a completed checkpoint stage according to its policy."""
+        policy = stage.checkpoint_resume_policy
+        if policy == "restore":
+            if not hasattr(stage, "_handle_checkpoint_skip"):
+                raise RuntimeError(
+                    f"Stage '{stage.name}' is restorable but has no checkpoint skip handler"
+                )
+            context = stage._handle_checkpoint_skip(context)
+            context.mark_complete(stage.name)
+        elif policy == "skip":
+            context.mark_complete(stage.name)
+        else:
+            raise RuntimeError(f"Stage '{stage.name}' must be recomputed")
+        return context
+
+    def _restore_or_recompute_completed_stages(
+        self, ordered: list[Stage], context: PipelineContext
+    ) -> PipelineContext:
+        """Restore safe completed stages, then clear volatile state for recomputation."""
+        assert context.checkpoint_state is not None
+        for stage in ordered:
+            if not context.checkpoint_state.should_skip_step(stage.name):
+                continue
+
+            policy = stage.checkpoint_resume_policy
+            if policy in {"restore", "skip"}:
+                logger.info(f"Restoring completed stage from checkpoint: {stage.name}")
+                context = self._restore_completed_stage(stage, context)
+                continue
+
+            logger.info(
+                "Recomputing checkpoint-completed stage '%s' and downstream stages",
+                stage.name,
+            )
+            self._clear_stage_and_downstream(stage.name, ordered, context.checkpoint_state)
+            break
+        return context
 
     def _get_stages_to_execute_from(
         self, resume_from: str, stages: list[Stage], context: PipelineContext

--- a/variantcentrifuge/pipeline_core/stage.py
+++ b/variantcentrifuge/pipeline_core/stage.py
@@ -90,6 +90,15 @@ class Stage(ABC):
         return False
 
     @property
+    def checkpoint_resume_policy(self) -> str:
+        """How completed checkpoint state should be handled after process restart.
+
+        The conservative default is to recompute because most stages mutate in-memory
+        context state that is not durable across process restarts.
+        """
+        return "recompute"
+
+    @property
     def estimated_runtime(self) -> float:
         """Estimated runtime in seconds for scheduling optimization.
 
@@ -212,6 +221,15 @@ class Stage(ABC):
 
         except Exception as e:
             elapsed = time.time() - start_time
+            if context.checkpoint_state:
+                try:
+                    context.checkpoint_state.fail_step(self.name, str(e))
+                except Exception as checkpoint_error:
+                    logger.warning(
+                        "Failed to record checkpoint failure for stage '%s': %s",
+                        self.name,
+                        checkpoint_error,
+                    )
             logger.error(f"Stage '{self.name}' failed after {elapsed:.1f}s: {e}")
             raise
 

--- a/variantcentrifuge/stages/analysis_stages.py
+++ b/variantcentrifuge/stages/analysis_stages.py
@@ -656,6 +656,11 @@ class DataFrameLoadingStage(Stage):
         return "dataframe_loading"
 
     @property
+    def checkpoint_resume_policy(self) -> str:
+        """DataFrame state can be restored from TSV artifacts."""
+        return "restore"
+
+    @property
     def description(self) -> str:
         """Return a description of what this stage does."""
         return "Load data into DataFrame for analysis"
@@ -692,14 +697,14 @@ class DataFrameLoadingStage(Stage):
         # Find the most recent TSV file using the same logic as _process
         input_file = self._find_input_file(context)
 
-        if not input_file:
-            logger.warning("No TSV file found to restore DataFrame during checkpoint skip")
-            return context
+        if not input_file or not Path(input_file).exists():
+            raise RuntimeError(
+                "Cannot restore dataframe_loading from checkpoint: no TSV input file found"
+            )
 
-        # Check if we should use chunked processing - skip if parallel processing done
-        if self._should_use_chunks(context, input_file) and not context.config.get(
-            "chunked_processing_complete"
-        ):
+        # Check if we should use DataFrame chunked analysis.
+        dataframe_chunks_done = context.config.get("dataframe_chunked_analysis_complete", False)
+        if self._should_use_chunks(context, input_file) and not dataframe_chunks_done:
             logger.info("File too large, will use chunked processing (checkpoint skip)")
             context.config["use_chunked_processing"] = True
             # Don't load full DataFrame - chunked stages will handle it
@@ -742,6 +747,10 @@ class DataFrameLoadingStage(Stage):
         else:
             # Fallback to context.data, but verify it's a TSV file
             input_file = context.data
+            if not input_file:
+                raise RuntimeError(
+                    "Cannot restore dataframe_loading from checkpoint: no TSV input file found"
+                )
             if input_file and (
                 str(input_file).endswith(".vcf.gz") or str(input_file).endswith(".vcf")
             ):
@@ -772,10 +781,9 @@ class DataFrameLoadingStage(Stage):
         # Find the input file
         input_file = self._find_input_file(context)
 
-        # Check if we should use chunked processing - skip if parallel processing done
-        if self._should_use_chunks(context, input_file) and not context.config.get(
-            "chunked_processing_complete"
-        ):
+        # Check if we should use DataFrame chunked analysis.
+        dataframe_chunks_done = context.config.get("dataframe_chunked_analysis_complete", False)
+        if self._should_use_chunks(context, input_file) and not dataframe_chunks_done:
             logger.info("File too large, will use chunked processing")
             context.config["use_chunked_processing"] = True
             # Don't load full DataFrame - chunked stages will handle it
@@ -918,6 +926,11 @@ class CustomAnnotationStage(Stage):
         # Annotation config is handled in setup stages if needed
         return {"dataframe_loading"}
 
+    @property
+    def soft_dependencies(self) -> set[str]:
+        """Run after chunked analysis when that stage is active."""
+        return {"chunked_analysis"}
+
     def _has_annotation_config(self) -> bool:
         """Check if annotation config stage exists."""
         return True  # Simplified
@@ -1002,7 +1015,7 @@ class InheritanceAnalysisStage(Stage):
     def soft_dependencies(self) -> set[str]:
         """Return the set of stage names that should run before if present."""
         # Prefer to run after custom_annotation if it exists
-        return {"custom_annotation"}
+        return {"custom_annotation", "chunked_analysis"}
 
     def _process(self, context: PipelineContext) -> PipelineContext:
         """Calculate inheritance patterns."""
@@ -1017,7 +1030,7 @@ class InheritanceAnalysisStage(Stage):
 
         # Check if using chunked processing - only defer if chunked processing is not complete
         if context.config.get("use_chunked_processing") and not context.config.get(
-            "chunked_processing_complete"
+            "dataframe_chunked_analysis_complete"
         ):
             logger.info(
                 f"Inheritance analysis ({inheritance_mode} mode) "
@@ -1292,7 +1305,7 @@ class VariantScoringStage(Stage):
     def soft_dependencies(self) -> set[str]:
         """Return the set of stage names that should run before if present."""
         # Prefer to run after annotations and inheritance if they exist
-        return {"custom_annotation", "inheritance_analysis"}
+        return {"custom_annotation", "inheritance_analysis", "chunked_analysis"}
 
     def _process(self, context: PipelineContext) -> PipelineContext:
         """Apply variant scoring."""
@@ -1302,7 +1315,7 @@ class VariantScoringStage(Stage):
 
         # Check if using chunked processing - only defer if chunked processing is not complete
         if context.config.get("use_chunked_processing") and not context.config.get(
-            "chunked_processing_complete"
+            "dataframe_chunked_analysis_complete"
         ):
             logger.info("Scoring will be applied during chunked processing")
             return context
@@ -1383,15 +1396,14 @@ class StatisticsGenerationStage(Stage):
 
         # Check if using chunked processing - generate statistics after chunks are combined
         if context.config.get("use_chunked_processing") and not context.config.get(
-            "chunked_processing_complete"
+            "dataframe_chunked_analysis_complete"
         ):
             logger.info("Statistics will be generated after chunked processing completes")
             return context
 
         df = context.current_dataframe
         if df is None:
-            logger.warning("No DataFrame loaded for statistics")
-            return context
+            raise RuntimeError("No DataFrame loaded for statistics")
 
         # Get stats config
         stats_config_path = context.config.get("stats_config")
@@ -1543,7 +1555,7 @@ class VariantAnalysisStage(Stage):
         # because analyze_variants creates a new DataFrame
         # Run after custom_annotation to ensure deterministic column ordering
         # CRITICAL: Run after inheritance_analysis to preserve inheritance columns
-        return {"custom_annotation", "inheritance_analysis"}
+        return {"custom_annotation", "inheritance_analysis", "chunked_analysis"}
 
     def _process(self, context: PipelineContext) -> PipelineContext:
         """Run variant analysis."""
@@ -1924,7 +1936,7 @@ class GeneBurdenAnalysisStage(Stage):
     def soft_dependencies(self) -> set[str]:
         """Return the set of stage names that should run before if present."""
         # Prefer to run after custom_annotation if it exists
-        return {"custom_annotation"}
+        return {"custom_annotation", "chunked_analysis"}
 
     def _handle_checkpoint_skip(self, context: PipelineContext) -> PipelineContext:
         """Handle the case where this stage is skipped by checkpoint system.
@@ -1959,6 +1971,62 @@ class GeneBurdenAnalysisStage(Stage):
 
         return context
 
+    def _resolve_gene_burden_output(self, context: PipelineContext) -> tuple[str, str | None]:
+        """Resolve and persist the gene burden sidecar output path."""
+        burden_output = context.config.get("gene_burden_output")
+        if not burden_output:
+            output_dir = context.config.get("output_dir", "output")
+            output_file = context.config.get("output_file")
+            if output_file and output_file != "-":
+                output_path = Path(output_file)
+                if not output_path.is_absolute():
+                    output_path = Path(output_dir) / output_path
+                name = output_path.name
+                if name.endswith(".tsv.gz"):
+                    base_name = name[: -len(".tsv.gz")]
+                elif name.endswith(".tsv"):
+                    base_name = name[: -len(".tsv")]
+                else:
+                    base_name = output_path.stem
+                burden_output = str(output_path.with_name(f"{base_name}.gene_burden.tsv"))
+            else:
+                base_name = context.config.get("output_file_base", "gene_burden_results")
+                burden_output = str(Path(output_dir) / f"{base_name}.gene_burden.tsv")
+            context.config["gene_burden_output"] = burden_output
+
+        compression = "gzip" if str(burden_output).endswith(".gz") else None
+        return burden_output, compression
+
+    def _gene_burden_output_columns(self, context: PipelineContext) -> list[str]:
+        """Return the header schema for empty gene burden output."""
+        mode = context.config.get("gene_burden_mode", "alleles")
+        if mode == "samples":
+            return [
+                "GENE",
+                "proband_count",
+                "control_count",
+                "proband_carrier_count",
+                "control_carrier_count",
+                "raw_p_value",
+                "corrected_p_value",
+                "odds_ratio",
+                "or_ci_lower",
+                "or_ci_upper",
+                "n_qualifying_variants",
+            ]
+        return [
+            "GENE",
+            "proband_count",
+            "control_count",
+            "proband_allele_count",
+            "control_allele_count",
+            "raw_p_value",
+            "corrected_p_value",
+            "odds_ratio",
+            "or_ci_lower",
+            "or_ci_upper",
+        ]
+
     def _process(self, context: PipelineContext) -> PipelineContext:
         """Perform gene burden analysis."""
         if not context.config.get("perform_gene_burden"):
@@ -1967,7 +2035,7 @@ class GeneBurdenAnalysisStage(Stage):
 
         # Check if using chunked processing - gene burden should be done after chunks are combined
         if context.config.get("use_chunked_processing") and not context.config.get(
-            "chunked_processing_complete"
+            "dataframe_chunked_analysis_complete"
         ):
             logger.info("Gene burden analysis will be performed after chunked processing completes")
             return context
@@ -1998,8 +2066,13 @@ class GeneBurdenAnalysisStage(Stage):
             return context
 
         df = context.current_dataframe
-        if df is None or df.empty:
-            logger.warning("No DataFrame loaded for gene burden analysis")
+        if df is None:
+            raise RuntimeError("No DataFrame loaded for gene burden analysis")
+        if df.empty:
+            burden_output, compression = self._resolve_gene_burden_output(context)
+            empty = pd.DataFrame(columns=self._gene_burden_output_columns(context))
+            empty.to_csv(burden_output, sep="\t", index=False, compression=cast(Any, compression))
+            context.gene_burden_results = empty
             return context
 
         # Check if DataFrame has required GENE column
@@ -2081,32 +2154,7 @@ class GeneBurdenAnalysisStage(Stage):
         context.gene_burden_results = burden_results
 
         # Write results to output file
-        burden_output = context.config.get("gene_burden_output")
-        if not burden_output:
-            # Create a sidecar next to the requested final output when possible.
-            output_dir = context.config.get("output_dir", "output")
-            output_file = context.config.get("output_file")
-            if output_file and output_file != "-":
-                output_path = Path(output_file)
-                if not output_path.is_absolute():
-                    output_path = Path(output_dir) / output_path
-                name = output_path.name
-                if name.endswith(".tsv.gz"):
-                    base_name = name[: -len(".tsv.gz")]
-                elif name.endswith(".tsv"):
-                    base_name = name[: -len(".tsv")]
-                else:
-                    base_name = output_path.stem
-                burden_output = str(output_path.with_name(f"{base_name}.gene_burden.tsv"))
-            else:
-                base_name = context.config.get("output_file_base", "gene_burden_results")
-                burden_output = str(Path(output_dir) / f"{base_name}.gene_burden.tsv")
-
-            # Save the generated path back into the context for other stages to use.
-            context.config["gene_burden_output"] = burden_output
-
-        # Treat gene burden as a user-facing sidecar output, not an intermediate.
-        compression = "gzip" if str(burden_output).endswith(".gz") else None
+        burden_output, compression = self._resolve_gene_burden_output(context)
 
         burden_results.to_csv(
             burden_output, sep="\t", index=False, compression=cast(Any, compression)
@@ -2460,7 +2508,7 @@ class AssociationAnalysisStage(Stage):
     @property
     def soft_dependencies(self) -> set[str]:
         """Return the set of stage names that should run before if present."""
-        return {"custom_annotation", "pca_computation"}
+        return {"custom_annotation", "pca_computation", "chunked_analysis"}
 
     @property
     def parallel_safe(self) -> bool:
@@ -2504,6 +2552,35 @@ class AssociationAnalysisStage(Stage):
 
         return context
 
+    def _association_output_columns(self, test_names: list[str]) -> list[str]:
+        """Return the header schema for empty association output."""
+        columns = [
+            "gene",
+            "n_cases",
+            "n_controls",
+            "n_variants",
+        ]
+        for test_name in test_names:
+            columns.extend([f"{test_name}_pvalue", f"{test_name}_qvalue"])
+        columns.extend(["primary_test", "primary_pvalue", "primary_qvalue", "warnings"])
+        return list(dict.fromkeys(columns))
+
+    def _resolve_association_output(self, context: PipelineContext) -> tuple[str, str | None]:
+        """Resolve and persist the association sidecar output path."""
+        assoc_output = context.config.get("association_output")
+        if not assoc_output:
+            output_dir = context.config.get("output_dir", "output")
+            base_name = context.config.get("output_file_base", "association_results")
+            assoc_output = str(Path(output_dir) / f"{base_name}.association.tsv")
+            context.config["association_output"] = assoc_output
+
+        use_compression = context.config.get("gzip_intermediates", True)
+        if use_compression and not str(assoc_output).endswith(".gz"):
+            assoc_output = str(assoc_output) + ".gz"
+            context.config["association_output"] = assoc_output
+            return assoc_output, "gzip"
+        return assoc_output, None
+
     def _process(self, context: PipelineContext) -> PipelineContext:
         """Perform association analysis."""
         if not context.config.get("perform_association"):
@@ -2521,6 +2598,14 @@ class AssociationAnalysisStage(Stage):
                 f"control_samples={len(control_samples) if control_samples else 0}"
             )
             return context
+
+        # Get DataFrame before constructing association engines so broken resume state
+        # produces a direct state-restoration error.
+        df = context.current_dataframe
+        if df is None:
+            df = context.variants_df
+        if df is None:
+            raise RuntimeError("No DataFrame loaded for association analysis")
 
         # PCA-02: pick up pca_file from PCAComputationStage result (Phase 32)
         pca_result = context.get_result("pca_computation")
@@ -2546,16 +2631,15 @@ class AssociationAnalysisStage(Stage):
             or ["fisher"]
         )
 
+        if df.empty:
+            assoc_output, compression = self._resolve_association_output(context)
+            empty = pd.DataFrame(columns=self._association_output_columns(test_names))
+            empty.to_csv(assoc_output, sep="\t", index=False, compression=cast(Any, compression))
+            context.association_results = empty
+            return context
+
         # Eager dependency check: instantiate engine (also calls check_dependencies per test)
         engine = AssociationEngine.from_names(test_names, assoc_config)
-
-        # Get DataFrame
-        df = context.current_dataframe
-        if df is None:
-            df = context.variants_df
-        if df is None or df.empty:
-            logger.warning("No DataFrame loaded for association analysis")
-            return context
 
         if "GENE" not in df.columns:
             logger.error("DataFrame missing required 'GENE' column for association analysis")
@@ -2871,21 +2955,7 @@ class AssociationAnalysisStage(Stage):
         results_df["warnings"] = results_df["gene"].map(warnings_by_gene).fillna("")
 
         # Write results to output file
-        assoc_output = context.config.get("association_output")
-        if not assoc_output:
-            output_dir = context.config.get("output_dir", "output")
-            base_name = context.config.get("output_file_base", "association_results")
-            assoc_output = str(Path(output_dir) / f"{base_name}.association.tsv")
-            context.config["association_output"] = assoc_output
-
-        # Apply compression based on configuration
-        use_compression = context.config.get("gzip_intermediates", True)
-        if use_compression and not str(assoc_output).endswith(".gz"):
-            assoc_output = str(assoc_output) + ".gz"
-            context.config["association_output"] = assoc_output
-            compression = "gzip"
-        else:
-            compression = None
+        assoc_output, compression = self._resolve_association_output(context)
 
         results_df.to_csv(assoc_output, sep="\t", index=False, compression=cast(Any, compression))
         logger.info(f"Wrote association results to {assoc_output}")
@@ -3005,6 +3075,11 @@ class ChunkedAnalysisStage(Stage):
         return "chunked_analysis"
 
     @property
+    def checkpoint_resume_policy(self) -> str:
+        """Chunked analysis can restore DataFrame state from its output TSV."""
+        return "restore"
+
+    @property
     def description(self) -> str:
         """Return a description of what this stage does."""
         return "Process large files in memory-efficient chunks"
@@ -3032,6 +3107,39 @@ class ChunkedAnalysisStage(Stage):
             "scoring_config_loading",  # Optional scoring config
             "pedigree_loading",  # Optional pedigree data
         }
+
+    def _handle_checkpoint_skip(self, context: PipelineContext) -> PipelineContext:
+        """Restore chunked DataFrame analysis state from its durable TSV artifact."""
+        chunked_tsv = context.chunked_analysis_tsv
+        if not chunked_tsv:
+            base = context.workspace.get_intermediate_path("chunked_analysis_results.tsv")
+            gz = Path(str(base) + ".gz")
+            chunked_tsv = gz if gz.exists() else base
+
+        if not chunked_tsv or not Path(chunked_tsv).exists():
+            raise RuntimeError(
+                "Cannot restore chunked_analysis from checkpoint: "
+                f"chunked output missing: {chunked_tsv}"
+            )
+
+        compression = "gzip" if str(chunked_tsv).endswith(".gz") else None
+        df, rename_map = load_optimized_dataframe(
+            str(chunked_tsv),
+            sep="\t",
+            compression=compression,
+            on_bad_lines="warn",
+        )
+        context.current_dataframe = df
+        context.column_rename_map = rename_map
+        context.chunked_analysis_tsv = Path(chunked_tsv)
+        context.config["dataframe_chunked_analysis_complete"] = True
+        context.config["use_chunked_processing"] = True
+        logger.info(
+            "Restored %d variants from chunked analysis checkpoint artifact: %s",
+            len(df),
+            chunked_tsv,
+        )
+        return context
 
     def _has_configs(self) -> bool:
         """Check if config stages exist."""
@@ -3160,9 +3268,10 @@ class ChunkedAnalysisStage(Stage):
             input_file = context.genotype_replaced_tsv
         elif context.extracted_tsv:
             input_file = context.extracted_tsv
+        elif context.data:
+            input_file = Path(context.data)
         else:
-            logger.error("No TSV file available for chunked processing")
-            return context
+            raise RuntimeError("No TSV file available for chunked processing")
 
         logger.info(f"Processing {input_file} in chunks of {chunk_size} variants")
 
@@ -3253,7 +3362,8 @@ class ChunkedAnalysisStage(Stage):
                     f"{[len(chunk) if chunk is not None else 'None' for chunk in output_chunks]}"
                 )
                 context.current_dataframe = pd.DataFrame()
-            context.config["chunked_processing_complete"] = True
+            context.config["dataframe_chunked_analysis_complete"] = True
+            context.config.pop("chunked_processing_complete", None)
 
             # Write chunked analysis results to a new TSV file for other stages
             chunked_output_path = context.workspace.get_intermediate_path(
@@ -3280,7 +3390,7 @@ class ChunkedAnalysisStage(Stage):
             )
             logger.info(f"Chunked analysis results written to: {chunked_output_path}")
         else:
-            logger.warning("No chunks were processed")
+            raise RuntimeError("No chunks were processed")
 
         return context
 

--- a/variantcentrifuge/stages/output_stages.py
+++ b/variantcentrifuge/stages/output_stages.py
@@ -189,7 +189,7 @@ class VariantIdentifierStage(Stage):
     def soft_dependencies(self) -> set[str]:
         """Return the set of stage names that should run before if present."""
         # Should run after variant_analysis because it creates a new DataFrame
-        return {"variant_analysis"}
+        return {"variant_analysis", "chunked_analysis"}
 
     @property
     def parallel_safe(self) -> bool:
@@ -567,7 +567,7 @@ class TSVOutputStage(Stage):
         """Return the set of stage names that should run before if present."""
         # Soft dependencies are optional - if these stages exist, we should run after them
         # This includes all stages that might modify the DataFrame
-        return {"variant_scoring", "final_filtering", "pseudonymization"}
+        return {"variant_scoring", "final_filtering", "pseudonymization", "chunked_analysis"}
 
     def _process(self, context: PipelineContext) -> PipelineContext:
         """Write final TSV output."""
@@ -577,6 +577,8 @@ class TSVOutputStage(Stage):
         if context.config.get("use_chunked_processing") and df is None:
             # Check if chunked analysis results are available
             if hasattr(context, "chunked_analysis_tsv") and context.chunked_analysis_tsv:
+                if not Path(context.chunked_analysis_tsv).exists():
+                    raise RuntimeError("No data to write")
                 logger.info(f"Using chunked analysis results from: {context.chunked_analysis_tsv}")
                 # Copy chunked results to final output location
                 output_file = context.config.get("output_file")
@@ -599,11 +601,11 @@ class TSVOutputStage(Stage):
                 output_filename = Path(output_file).name
                 context.final_output_path = context.workspace.output_dir / output_filename
                 logger.info(f"Chunked processing output: {context.final_output_path}")
-            return context
+                return context
+            raise RuntimeError("No data to write")
 
         if df is None:
-            logger.error("No data to write")
-            return context
+            raise RuntimeError("No data to write")
 
         # Phase 11: Keep per-sample GT columns available for analysis, but collapse
         # them out of final materialized outputs unless users requested raw output.
@@ -689,6 +691,10 @@ class TSVOutputStage(Stage):
 
         return context
 
+    def get_output_files(self, context: PipelineContext) -> list[Path]:
+        """Return the final TSV output for checkpoint tracking."""
+        return [context.final_output_path] if context.final_output_path else []
+
 
 class ExcelReportStage(Stage):
     """Generate Excel report with multiple sheets."""
@@ -727,8 +733,7 @@ class ExcelReportStage(Stage):
 
         input_file = context.final_output_path
         if not input_file or not input_file.exists():
-            logger.warning("No input file for Excel generation")
-            return context
+            raise RuntimeError("No input file for Excel generation")
 
         output_path = context.workspace.get_output_path("", ".xlsx")
 
@@ -784,6 +789,11 @@ class ExcelReportStage(Stage):
 
         context.report_paths["excel"] = output_path
         return context
+
+    def get_output_files(self, context: PipelineContext) -> list[Path]:
+        """Return the Excel report for checkpoint tracking."""
+        path = context.report_paths.get("excel")
+        return [path] if path else []
 
     def _add_additional_sheets(self, xlsx_file: str, context: PipelineContext) -> None:
         """Add additional sheets to the Excel file."""
@@ -1108,6 +1118,11 @@ class MetadataGenerationStage(Stage):
 
         context.report_paths["metadata"] = metadata_path
         return context
+
+    def get_output_files(self, context: PipelineContext) -> list[Path]:
+        """Return the metadata report for checkpoint tracking."""
+        path = context.report_paths.get("metadata")
+        return [path] if path else []
 
 
 class ArchiveCreationStage(Stage):

--- a/variantcentrifuge/stages/processing_stages.py
+++ b/variantcentrifuge/stages/processing_stages.py
@@ -706,31 +706,14 @@ class GenotypeReplacementStage(Stage):
         """Return the set of stage names this stage depends on."""
         return {"field_extraction", "sample_config_loading"}
 
+    @property
+    def checkpoint_resume_policy(self) -> str:
+        """Phase-11 no-op can be skipped without restoring a file."""
+        return "skip"
+
     def _handle_checkpoint_skip(self, context: PipelineContext) -> PipelineContext:
-        """Handle the case where this stage is skipped by checkpoint system.
-
-        When this stage is skipped, we need to restore the context paths
-        so that subsequent stages can find the genotype_replaced_tsv file.
-        """
-        # Reconstruct the expected output path
-        output_tsv = context.workspace.get_intermediate_path(
-            f"{context.workspace.base_name}.genotype_replaced.tsv"
-        )
-
-        # Handle gzip compression
-        if context.config.get("gzip_intermediates", True):
-            output_tsv = Path(str(output_tsv) + ".gz")
-
-        # Check if the file exists and restore context
-        if output_tsv.exists():
-            context.genotype_replaced_tsv = output_tsv
-            context.data = output_tsv
-            logger.info(
-                f"Restored genotype_replaced_tsv path to {output_tsv} after checkpoint skip"
-            )
-        else:
-            logger.warning(f"Expected genotype_replaced_tsv file not found: {output_tsv}")
-
+        """Clean no-op restore for Phase-11 genotype replacement."""
+        logger.info("Genotype replacement is a Phase-11 no-op; nothing to restore")
         return context
 
     def _process(self, context: PipelineContext) -> PipelineContext:
@@ -752,8 +735,6 @@ class GenotypeReplacementStage(Stage):
 
     def get_output_files(self, context: PipelineContext) -> list[Path]:
         """Return output files for checkpoint tracking."""
-        if hasattr(context, "genotype_replaced_tsv") and context.genotype_replaced_tsv:
-            return [context.genotype_replaced_tsv]
         return []
 
 
@@ -764,6 +745,11 @@ class PhenotypeIntegrationStage(Stage):
     def name(self) -> str:
         """Return the stage name."""
         return "phenotype_integration"
+
+    @property
+    def checkpoint_resume_policy(self) -> str:
+        """Phenotype integration can restore its output path or no-op cleanly."""
+        return "restore"
 
     @property
     def description(self) -> str:
@@ -828,8 +814,13 @@ class PhenotypeIntegrationStage(Stage):
             context.phenotypes_added_tsv = output_tsv
             context.data = output_tsv
             logger.info(f"Restored phenotypes_added_tsv path to {output_tsv} after checkpoint skip")
+        elif not self._has_phenotype_data(context):
+            logger.info("No phenotype data configured; nothing to restore")
         else:
-            logger.warning(f"Expected phenotypes_added_tsv file not found: {output_tsv}")
+            raise RuntimeError(
+                "Cannot restore phenotype_integration from checkpoint: "
+                f"expected TSV missing: {output_tsv}"
+            )
 
         return context
 
@@ -979,6 +970,11 @@ class ParallelCompleteProcessingStage(Stage):
         return "parallel_complete_processing"
 
     @property
+    def checkpoint_resume_policy(self) -> str:
+        """The merged TSV is durable and can restore downstream input paths."""
+        return "restore"
+
+    @property
     def description(self) -> str:
         """Return a description of what this stage does."""
         return "Process variants in parallel with complete pipeline per chunk"
@@ -1076,15 +1072,19 @@ class ParallelCompleteProcessingStage(Stage):
         if (intermediate_dir / f"{base_name}.extracted.tsv.gz").exists():
             merged_tsv = intermediate_dir / f"{base_name}.extracted.tsv.gz"
 
-        # Validate the merged TSV exists and is valid
-        if merged_tsv.exists() and self._validate_chunk_tsv(merged_tsv):
-            logger.info(f"Restored valid merged TSV: {merged_tsv}")
-        else:
-            logger.warning(f"Expected merged TSV not found or invalid: {merged_tsv}")
+        # Validate the merged TSV exists and is valid before mutating context.
+        if not merged_tsv.exists() or not self._validate_chunk_tsv(merged_tsv):
+            raise RuntimeError(
+                "Cannot restore parallel_complete_processing from checkpoint: "
+                f"merged TSV missing or invalid: {merged_tsv}"
+            )
+        logger.info(f"Restored valid merged TSV: {merged_tsv}")
 
         # Restore context state that would have been set
         context.extracted_tsv = merged_tsv
         context.data = merged_tsv
+        context.config["parallel_vcf_processing_complete"] = True
+        context.config.pop("chunked_processing_complete", None)
 
         # Mark all the stages this stage would have completed
         context.mark_complete("variant_extraction")
@@ -1134,8 +1134,10 @@ class ParallelCompleteProcessingStage(Stage):
         context.mark_complete("snpsift_filtering")
         context.mark_complete("field_extraction")
 
-        # Mark chunked processing as complete so analysis stages can run
-        context.config["chunked_processing_complete"] = True
+        # Mark parallel VCF chunk processing as complete. DataFrame chunked
+        # analysis has a separate completion flag.
+        context.config["parallel_vcf_processing_complete"] = True
+        context.config.pop("chunked_processing_complete", None)
 
         # Cleanup chunks
         cleanup_start = self._start_subtask("cleanup")

--- a/variantcentrifuge/stages/setup_stages.py
+++ b/variantcentrifuge/stages/setup_stages.py
@@ -96,6 +96,11 @@ class ConfigurationLoadingStage(Stage):
         return "configuration_loading"
 
     @property
+    def checkpoint_resume_policy(self) -> str:
+        """Configuration is already present in the new CLI context."""
+        return "skip"
+
+    @property
     def description(self) -> str:
         """Return a description of what this stage does."""
         return "Load configuration and merge with CLI arguments"
@@ -250,6 +255,11 @@ class PhenotypeLoadingStage(Stage):
         return "phenotype_loading"
 
     @property
+    def checkpoint_resume_policy(self) -> str:
+        """Phenotype data can be restored by the checkpoint skip handler."""
+        return "restore"
+
+    @property
     def description(self) -> str:
         """Return a description of what this stage does."""
         return "Load phenotype data"
@@ -313,8 +323,9 @@ class PhenotypeLoadingStage(Stage):
                 context.config["phenotypes"] = phenotypes  # For compatibility
                 logger.debug(f"Restored phenotypes for {len(phenotypes)} samples (checkpoint skip)")
             else:
-                logger.warning(
-                    f"No phenotype data found during checkpoint skip from {phenotype_file}"
+                raise ValueError(
+                    f"No phenotype data loaded from {phenotype_file}. "
+                    "Check file formatting and column names."
                 )
         else:
             logger.debug("No phenotype configuration found during checkpoint skip")
@@ -329,6 +340,11 @@ class ScoringConfigLoadingStage(Stage):
     def name(self) -> str:
         """Return the stage name."""
         return "scoring_config_loading"
+
+    @property
+    def checkpoint_resume_policy(self) -> str:
+        """Scoring configuration can be restored by the checkpoint skip handler."""
+        return "restore"
 
     @property
     def description(self) -> str:
@@ -382,9 +398,7 @@ class ScoringConfigLoadingStage(Stage):
                     f"{len(scoring_config.get('formulas', {}))} formulas (checkpoint skip)"
                 )
             except Exception as e:
-                logger.warning(
-                    f"Failed to restore scoring configuration during checkpoint skip: {e}"
-                )
+                raise ValueError(f"Failed to restore scoring configuration: {e}") from e
         else:
             logger.debug("No scoring configuration specified during checkpoint skip")
 
@@ -398,6 +412,11 @@ class PedigreeLoadingStage(Stage):
     def name(self) -> str:
         """Return the stage name."""
         return "pedigree_loading"
+
+    @property
+    def checkpoint_resume_policy(self) -> str:
+        """Pedigree data can be restored by the checkpoint skip handler."""
+        return "restore"
 
     @property
     def description(self) -> str:
@@ -458,7 +477,7 @@ class PedigreeLoadingStage(Stage):
                     f"(checkpoint skip)"
                 )
             except Exception as e:
-                logger.warning(f"Failed to restore pedigree file during checkpoint skip: {e}")
+                raise ValueError(f"Failed to restore pedigree file: {e}") from e
         else:
             logger.debug("No pedigree file specified during checkpoint skip")
 
@@ -472,6 +491,11 @@ class AnnotationConfigLoadingStage(Stage):
     def name(self) -> str:
         """Return the stage name."""
         return "annotation_config_loading"
+
+    @property
+    def checkpoint_resume_policy(self) -> str:
+        """Annotation configuration can be restored by the checkpoint skip handler."""
+        return "restore"
 
     @property
     def description(self) -> str:
@@ -567,6 +591,11 @@ class SampleConfigLoadingStage(Stage):
     def name(self) -> str:
         """Return the stage name."""
         return "sample_config_loading"
+
+    @property
+    def checkpoint_resume_policy(self) -> str:
+        """Sample configuration can be restored by the checkpoint skip handler."""
+        return "restore"
 
     @property
     def description(self) -> str:
@@ -709,8 +738,7 @@ class SampleConfigLoadingStage(Stage):
         vcf_file = context.config.get("vcf_file")
 
         if not vcf_file:
-            logger.warning("No VCF file specified in configuration during checkpoint skip")
-            return context
+            raise ValueError("No VCF file specified in configuration during checkpoint skip")
 
         # Restore VCF samples
         logger.debug(f"Restoring VCF samples from {vcf_file} (checkpoint skip)")
@@ -778,6 +806,11 @@ class PhenotypeCaseControlAssignmentStage(Stage):
     def name(self) -> str:
         """Return the stage name."""
         return "phenotype_case_control_assignment"
+
+    @property
+    def checkpoint_resume_policy(self) -> str:
+        """Case/control assignment can be restored by the checkpoint skip handler."""
+        return "restore"
 
     @property
     def description(self) -> str:
@@ -1164,10 +1197,9 @@ class PhenotypeCaseControlAssignmentStage(Stage):
         # Get VCF samples
         vcf_samples = getattr(context, "vcf_samples", [])
         if not vcf_samples:
-            logger.warning(
+            raise ValueError(
                 "No VCF samples found, cannot restore phenotype-based assignment (checkpoint skip)"
             )
-            return context
 
         # Get phenotype file parameters
         phenotype_file = context.config.get("phenotype_file")
@@ -1175,11 +1207,10 @@ class PhenotypeCaseControlAssignmentStage(Stage):
         phenotype_value_column = context.config.get("phenotype_value_column")
 
         if not phenotype_file or not phenotype_sample_column or not phenotype_value_column:
-            logger.warning(
+            raise ValueError(
                 "Missing phenotype file parameters, cannot restore phenotype-based assignment "
                 "(checkpoint skip)"
             )
-            return context
 
         # Re-compute phenotype-based assignments
         try:
@@ -1205,9 +1236,9 @@ class PhenotypeCaseControlAssignmentStage(Stage):
             )
 
         except Exception as e:
-            logger.warning(
+            raise ValueError(
                 f"Failed to restore phenotype-based assignment during checkpoint skip: {e}"
-            )
+            ) from e
 
         return context
 


### PR DESCRIPTION
## Summary
- add explicit checkpoint resume policies so durable stages restore, no-op stages skip, and volatile DataFrame stages recompute after persisted checkpoint completion is cleared
- restore chunked analysis DataFrame state from durable TSV artifacts, split parallel VCF completion from DataFrame chunked-analysis completion, and abort resume on missing required artifacts
- harden requested outputs so missing DataFrames fail while valid empty DataFrames write header-only TSV, association, and gene burden outputs
- fix categorical GT columns in association genotype matrix construction by converting before filling missing genotypes with `./.`
- update resume docs and issue #101 execution checklist

## Verification
- pytest tests/unit/pipeline/test_stage.py -q
- pytest tests/unit/test_parallel_stage_resume.py -q
- pytest tests/unit/stages/test_analysis_stages.py -q
- pytest tests/unit/pipeline/test_runner.py -q
- pytest tests/unit/test_association_stage.py -q
- pytest tests/unit/test_gene_burden_regression.py -q
- pytest tests/unit/stages/test_output_stages.py -q
- pytest tests/test_checkpoint.py -q
- pytest tests/unit/test_association_genotype_matrix.py -q
- pytest tests/unit/test_association_stage.py tests/unit/test_score_column_association_integration.py -q
- pytest tests/test_checkpoint.py tests/test_checkpoint_resume.py tests/test_checkpoint_parallel.py tests/test_checkpoint_parallel_resume.py -q
- pytest tests/unit/stages tests/unit/pipeline -q
- pytest tests/integration/test_checkpoint_resume_state_restoration.py -q
- make ci-check

## Notes
- Does not include the unrelated issue #106 superpowers docs left untracked locally.
