### PR TITLE
feat: cohort-stratified rare-variant score-statistic meta-analysis (#112)

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -58,7 +58,13 @@ Accurate inheritance pattern deduction and variant prioritization from multi-sam
 
 ### Active
 
-(No active milestone — next TBD via /gsd:new-milestone)
+**Cohort-stratified rare-variant score-statistic meta-analysis** (#112, branch `feat/cohort-meta-analysis`) — in review
+
+- Per-stratum score/covariance artifacts (`U = Gᵀr`, projection-adjusted `V = GᵀPG`, aggregate-only — no per-sample rows) exported from the existing SKAT machinery
+- New `variantcentrifuge-meta` CLI: study manifest → canonical-key union alignment → pooled-frequency weight harmonisation → common-effect burden/SKAT/SKAT-O meta + heterogeneity (Cochran Q, I², leave-one-cohort-out) → exome-wide FDR
+- Binary traits; reuses the Davies chain and SKAT-O omnibus unchanged — a single-stratum meta reproduces `_test_skat`/`_test_skato` exactly (golden-gate tests)
+- Comparability guardrails: refuses to pool strata that disagree on build/annotation/mask or that share samples; no silent p-value-combination fallback
+- 33 new tests covering all six issue acceptance criteria; scope reversal ratified (see Out of Scope + Key Decisions)
 
 ### Out of Scope
 
@@ -67,8 +73,10 @@ Accurate inheritance pattern deduction and variant prioritization from multi-sam
 - Report generation validation (#61) — separate milestone
 - Polars migration — unacceptable risk for clinical tool with deep pandas integration
 - Free-threaded Python 3.13+ — numpy/pandas lack support
-- Meta-analysis (RAREMETAL, Meta-SAIGE) — different problem: combining results across cohorts
-- Mixed model / GRM (SAIGE-GENE approach) — biobank-scale; PCs + kinship exclusion sufficient for GCKD
+- External/public control borrowing and cross-cohort participant linkage — the #112 meta-analysis combines per-cohort score statistics only; it never borrows, links, or pools raw samples
+- Quantitative-trait meta-analysis — deferred pending a coherent likelihood-score convention (binary only for the first release; the adversarial review showed the raw `U`/`V` pairing is inconsistent for σ²≠1)
+- Genotype-level SPA for severe case:control imbalance — deferred; the meta artifact stores raw `U`/`V`, so a saddlepoint path can be added without a schema change
+- Mixed model / GRM null backend (SAIGE-GENE approach) — biobank-scale; the #112 meta engine exposes an extensible null-model/covariance seam for it, but PCs + kinship exclusion remain the default for GCKD
 - Adaptive test selection per gene — post-hoc best-test selection inflates type I error
 
 ## Context
@@ -124,6 +132,10 @@ Accurate inheritance pattern deduction and variant prioritization from multi-sam
 | Sparse matrices deferred (streaming solves OOM) | Centering destroys sparsity for SKAT; benefit only at 10K+ samples | ✓ Good |
 | Compound het numpy-only worker reverted | 2x regression on real data; synthetic benchmarks misleading | ✓ Good (correct revert) |
 | Always benchmark with production-scale data | Synthetic (50 samples) showed gains; real (5125 samples) showed regression | ✓ Good (lesson learned) |
+| Adopt cohort meta-analysis (#112), reversing the prior non-goal | Real GCKD-adjacent need: two imbalanced case-control cohorts, one calibrated exome-wide discovery; the score `U` and covariance `V` are already computed by SKAT and thrown away | ✓ Ratified 2026-07-21 |
+| Decoupled design: per-cohort score artifacts + a separate `variantcentrifuge-meta` CLI | Matches RAREMETAL/MetaSKAT/seqMeta; per-cohort runs are unchanged and the meta step needs no VCF or external tools | ✓ Good |
+| Store `U`/`V` unweighted; harmonise weights from pooled MAF at meta time | Cohort-specific MAF weights would put `U`/`V` on incompatible scales | ✓ Good |
+| Binary-only first; SPA, GLMM/GRM, and quantitative behind interface seams | Binary is the issue's stated target; adversarial (Codex) review found the quantitative `U`/`V` scaling needs a separate likelihood-score convention | — Pending (deferred) |
 
 ---
-*Last updated: 2026-02-27 after v0.17.0 milestone completion*
+*Last updated: 2026-07-21 — cohort meta-analysis (#112) scope ratified*

--- a/docs/source/guides/index.md
+++ b/docs/source/guides/index.md
@@ -48,6 +48,7 @@ cancer_analysis
 inheritance_analysis
 cohort_analysis
 association_testing
+meta_analysis
 variant_scoring
 custom_filters
 ../user-guide/privacy_and_pseudonymization

--- a/docs/source/guides/meta_analysis.md
+++ b/docs/source/guides/meta_analysis.md
@@ -1,0 +1,113 @@
+# Cohort-Stratified Meta-Analysis
+
+VariantCentrifuge can combine two or more clinically distinct case-control
+**strata** into one calibrated rare-variant discovery analysis using
+**score-statistic meta-analysis** (issue #112). Unlike pooling with a cohort
+covariate, each stratum keeps its own null model, ascertainment, and case:control
+ratio; unlike combining per-gene p-values, the signed score and covariance are
+preserved so burden direction and kernel (SKAT) evidence are retained.
+
+> **Scope.** This is an analysis-engine feature for **binary traits**. Study-specific
+> phenotype eligibility, covariate choice, and QC remain caller responsibilities.
+> Quantitative traits, a mixed-model/GRM null, and a genotype-level saddlepoint
+> (SPA) for *severe* imbalance are deferred (see *Limitations*).
+
+## How it works
+
+The workflow mirrors RAREMETAL / MetaSKAT / seqMeta: each stratum exports a
+compact **score/covariance artifact**, then a separate step combines them.
+
+1. **Per-stratum artifact.** For every gene, VariantCentrifuge stores the
+   unweighted score vector `U = Gᵀr` (r = null residuals) and the
+   projection-adjusted covariance `V = GᵀPG`, plus per-variant observed ALT-allele
+   counts (`AC`) and allele numbers (`AN`). These are gene-level **aggregates** —
+   no per-sample genotypes or phenotype values — so artifacts are safe to move
+   between sites.
+2. **Meta step (`variantcentrifuge-meta`).** For each gene it aligns the strata on
+   a canonical `chrom:pos:ref:alt` key (union of variants; a variant absent in a
+   stratum contributes zero information there), harmonises weights from the
+   **pooled** frequency, and combines:
+   - **meta-burden** — common-effect score burden (`Z = 1ᵀS / √(1ᵀΣ1)`), with a
+     signed direction;
+   - **meta-SKAT** — kernel test via the Davies mixture chain;
+   - **meta-SKAT-O** — the optimal omnibus (the reported *primary* result);
+   - **heterogeneity** — Cochran's Q, I², per-stratum directions, and
+     leave-one-stratum-out.
+   Exome-wide multiplicity correction (BH/Bonferroni) is applied to the primary
+   p-value across genes.
+
+Weights are harmonised from the pooled ALT frequency `ΣAC/ΣAN`, using
+`MAF = min(af, 1-af)` for the `Beta(MAF; 1, 25)` weight. This is essential: a
+stratum's own MAF would put its `U`/`V` on an incompatible scale.
+
+### ACAT-O vs meta-analysis
+
+These are **different** operations and are kept distinct:
+
+- **Within-gene ACAT-O** (see the Association Testing guide) combines *tests/masks
+  within one cohort* via Cauchy combination.
+- **Cross-stratum meta-analysis** (this guide) combines the *score and covariance*
+  across cohorts. Per-cohort p-value combination is **never** used as a silent
+  substitute for the score-based common-effect test; an explicit ACAT companion is
+  available as a heterogeneity-robust complement only.
+
+## Study manifest
+
+A TSV, one row per stratum:
+
+```
+stratum_id	artifact_path
+adult_cohort	/data/meta/adult.npz
+pediatric_cohort	/data/meta/pediatric.npz
+```
+
+The meta step **refuses** (hard error, no silent fallback) when strata disagree on
+genome build, annotation version, mask definition, or trait type, or when their
+(hashed) sample sets overlap — overlap would violate the additive-covariance
+independence assumption. Sample non-overlap does not by itself establish
+independence for related or shared-control populations; that remains a caller
+assumption.
+
+## Running it
+
+```bash
+variantcentrifuge-meta \
+  --manifest study.tsv \
+  --output meta_results.tsv \
+  --weights beta:1,25 \
+  --correction fdr
+```
+
+Only `beta:a,b` and `uniform` weights are supported (the only schemes reproducible
+from the artifact). Output columns include `meta_burden_p`,
+`meta_burden_direction`, `meta_skat_p`, `meta_skato_p`, `meta_skato_rho`, `het_q`,
+`het_p`, `het_i2`, `per_stratum_directions`, `loo_min_p`, `primary_p`,
+`primary_q`, and a `status`/`warnings` pair (e.g. a non-converged stratum is
+excluded with an explicit warning).
+
+## API
+
+```python
+from variantcentrifuge.association.meta import (
+    compute_gene_score, meta_burden, meta_skat, meta_skato,
+)
+```
+
+`compute_gene_score(imputed_matrix, raw_dosage, null_model, variant_keys)` builds a
+`GeneScore`; the `meta_*` functions combine aligned strata. A single-stratum call
+reproduces the single-cohort SKAT/SKAT-O/burden result exactly — the correctness
+gate that ties the meta engine to the validated backend.
+
+## Calibration and limitations
+
+The common-effect score meta uses a normal/Davies approximation that is well
+calibrated under **moderate** imbalance. Under **severe** case:control imbalance the
+per-variant/burden normal approximation is anti-conservative in the tail; a
+calibrated result there requires a genotype-level saddlepoint (SPA) backend, which
+is **deferred**. The artifact stores the raw `U`/`V`, so an SPA meta path can be
+added without changing the schema. Likewise, `V` is stored as a full matrix, so a
+future relatedness-aware (GLMM/GRM) null drops in without a schema change.
+
+Independent cross-validation against MetaSKAT/seqMeta on shared synthetic data is
+recommended before publishing exome-wide claims (R is not guaranteed in CI, so the
+in-repo reference values are Python-native regression anchors).

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -70,6 +70,7 @@ guides/cancer_analysis
 guides/inheritance_analysis
 guides/cohort_analysis
 guides/association_testing
+guides/meta_analysis
 guides/variant_scoring
 guides/custom_filters
 user-guide/privacy_and_pseudonymization

--- a/docs/superpowers/plans/2026-07-20-cohort-meta-analysis.md
+++ b/docs/superpowers/plans/2026-07-20-cohort-meta-analysis.md
@@ -1,0 +1,240 @@
+# Cohort Meta-Analysis Implementation Plan
+
+> **For agentic workers:** implement task-by-task with TDD. Steps use checkbox (`- [ ]`) syntax.
+> Commits are DEFERRED — AGENTS.md forbids commits/push/PR without explicit user approval. Do the
+> work on branch `feat/cohort-meta-analysis`; leave it uncommitted for review.
+
+**Goal:** Add a score-statistic meta-analysis engine that combines per-stratum rare-variant
+association evidence (burden, SKAT, SKAT-O) from persisted score/covariance artifacts.
+
+**Architecture:** New `variantcentrifuge/association/meta/` package. Per-stratum artifacts hold
+unweighted score vector `U` and projection-adjusted covariance `V` (aggregates only). A
+`variantcentrifuge-meta` CLI aligns strata per gene, harmonises weights from pooled MAF, and
+reuses the existing Davies chain and SKAT-O omnibus to produce meta p-values plus heterogeneity.
+
+**Tech Stack:** Python 3.10+, numpy, scipy, statsmodels (all already deps). Reuses
+`association/backends/{python_backend,davies}.py`.
+
+## Global Constraints
+
+- Every new production module ≤ 600 physical lines (`make lint-loc`).
+- Do NOT add code to `python_backend.py` (allowlisted at 1132; must not grow) — import from it.
+- Never run `variantcentrifuge` on real data. Tests use synthetic fixtures only.
+- Artifacts/reports contain only aggregate quantities — never sample IDs or phenotype rows.
+- Single-stratum meta must reproduce `_test_skat`/`_test_skato`/burden (golden gate).
+- ruff N-series: scientific matrices use descriptive names (matches existing backend style).
+
+---
+
+### Task 1: Artifact schema + gene-level artifact computation
+
+**Files:**
+- Create: `variantcentrifuge/association/meta/__init__.py`
+- Create: `variantcentrifuge/association/meta/artifact.py`
+- Test: `tests/unit/test_meta_artifact.py`
+
+**Interfaces — Produces:**
+- `@dataclass ScoreCovarianceArtifact` with fields: `schema_version:int`, `stratum_id:str`,
+  `genome_build:str`, `annotation_version:str`, `mask_id:str`, `mask_hash:str`,
+  `trait_type:str`, `n_cases:int`, `n_controls:int`, `sample_id_hashes:list[str]`,
+  `genes:dict[str, GeneScore]`.
+- `@dataclass GeneScore` with: `variant_keys:list[str]`, `u:np.ndarray (p,)`,
+  `v:np.ndarray (p,p)`, `ac:np.ndarray (p,)`, `an:np.ndarray (p,)`, `null_converged:bool`.
+- `compute_gene_artifact(genotype_matrix, phenotype, covariates, variant_keys, trait_type) -> GeneScore`
+- `save_artifact(artifact, path) -> None` (`.npz` arrays + `<path>.meta.json`)
+- `load_artifact(path) -> ScoreCovarianceArtifact`
+
+**Key implementation (`compute_gene_artifact`):**
+```python
+from variantcentrifuge.association.backends.python_backend import PythonSKATBackend
+
+def compute_gene_artifact(genotype_matrix, phenotype, covariates, variant_keys, trait_type):
+    backend = PythonSKATBackend(); backend.detect_environment()
+    nm = backend.fit_null_model(phenotype, covariates, trait_type)
+    r = nm.extra["residuals"]
+    g = np.asarray(genotype_matrix, dtype=np.float64)
+    u = g.T @ r                                   # unweighted score  (p,)
+    x = nm.extra["design_matrix"]
+    if trait_type == "binary":
+        pi = nm.extra["mu_hat"] * (1.0 - nm.extra["mu_hat"]); phi = np.sqrt(pi)
+        z_phi = phi[:, None] * g
+        x_phi = phi[:, None] * x
+        x_pi = pi[:, None] * x
+        z_adj = z_phi - x_phi @ np.linalg.solve(x_phi.T @ x_phi, x_pi.T @ g)
+    else:
+        s2 = nm.extra["sigma2"]
+        z_adj = (g - x @ np.linalg.solve(x.T @ x, x.T @ g)) / np.sqrt(s2)
+    v = z_adj.T @ z_adj                            # projection-adjusted cov (p,p)
+    an = 2.0 * np.sum(~np.isnan(g), axis=0)        # (built before imputation in caller)
+    ac = np.nansum(g, axis=0)
+    return GeneScore(variant_keys, u, v, ac, an, bool(nm.extra))
+```
+Note: `an`/`ac` should be computed from the pre-imputation dosage; caller passes the raw matrix's
+column sums. For synthetic tests the imputed matrix is acceptable (documented).
+
+**Steps:** write failing test asserting `compute_gene_artifact` returns `u.shape==(p,)`,
+`v.shape==(p,p)`, `v` symmetric PSD → run (fail) → implement → run (pass) → round-trip
+save/load equality test → (commit deferred).
+
+---
+
+### Task 2: Golden consistency — single-stratum SKAT/SKAT-O/burden
+
+**Files:**
+- Create: `variantcentrifuge/association/meta/combine.py`
+- Test: `tests/unit/test_meta_combine_golden.py`
+
+**Interfaces — Produces:**
+- `meta_skat(u_list, v_list, weights) -> tuple[float|None, str]`  (p_value, p_method)
+- `meta_burden(u_list, v_list, weights) -> tuple[float|None, float, int]`  (p, beta, direction)
+- `meta_skato(u_list, v_list, weights) -> tuple[float|None, float|None]`  (p, rho)
+
+where `u_list[c]`, `v_list[c]` are ALREADY aligned to the union order (Task 3 provides alignment),
+`weights` is the harmonised per-variant weight vector.
+
+**Key implementation:**
+```python
+from variantcentrifuge.association.backends.davies import compute_pvalue
+from variantcentrifuge.association.backends.python_backend import _skato_get_pvalue, _SKATO_RHO_GRID
+import scipy.linalg, scipy.stats, numpy as np
+
+def _weighted(u_list, v_list, w):
+    s = sum(w * u for u in u_list)
+    sigma = sum((w[:, None] * v) * w[None, :] for v in v_list)
+    return s, sigma
+
+def meta_skat(u_list, v_list, w):
+    s, sigma = _weighted(u_list, v_list, w)
+    q = float(s @ s) / 2.0
+    lam = scipy.linalg.eigh(sigma / 2.0, eigvals_only=True, driver="evr")
+    pos = lam[lam >= 0]
+    if pos.size == 0: return None, "skip"
+    lam = lam[lam > pos.mean() / 100_000.0]
+    if lam.size == 0: return 1.0, "liu"
+    p, method, _ = compute_pvalue(q, lam)
+    return (None if not np.isfinite(p) else float(p)), method
+
+def meta_burden(u_list, v_list, w):
+    s, sigma = _weighted(u_list, v_list, w)
+    score = float(s.sum()); var = float(sigma.sum())
+    if var <= 0.0: return None, 0.0, 0
+    z = score / np.sqrt(var)
+    return float(2.0 * scipy.stats.norm.sf(abs(z))), score / var, int(np.sign(score))
+
+def meta_skato(u_list, v_list, w):
+    s, sigma = _weighted(u_list, v_list, w)
+    a = sigma / 2.0
+    lam, vec = scipy.linalg.eigh(a)
+    keep = lam > (lam[lam >= 0].mean() / 100_000.0 if np.any(lam >= 0) else 0)
+    if not np.any(keep): return None, None
+    b = (vec[:, keep] * np.sqrt(lam[keep])).T          # (k,p): b.T@b == a (kept subspace)
+    q_rho = np.array([((1 - r) * float(s @ s) + r * float(s.sum())**2) / 2.0
+                      for r in _SKATO_RHO_GRID])
+    p, per_rho = _skato_get_pvalue(q_rho, b, _SKATO_RHO_GRID)
+    rho = _SKATO_RHO_GRID[int(np.argmin(per_rho))]
+    return float(p), rho
+```
+
+**Golden test:** synthetic `(G, y, X)`; compute artifact `U`,`V`; weights = `Beta(maf;1,25)` from
+`G.mean(0)/2`; assert `meta_skat([U],[V],w)` p ≈ `PythonSKATBackend._test_skat` p (rtol 1e-6),
+`meta_skato` p ≈ `_test_skato` p, and `meta_burden` p ≈ projection-adjusted burden
+(cross-check `_test_skato` per-rho at rho=1).
+
+---
+
+### Task 3: Variant alignment + pooled-MAF weights
+
+**Files:**
+- Create: `variantcentrifuge/association/meta/align.py`
+- Test: `tests/unit/test_meta_align.py`
+
+**Interfaces — Produces:**
+- `canonical_key(chrom, pos, ref, alt) -> str`
+- `align_strata(gene_scores: list[GeneScore]) -> tuple[list[np.ndarray], list[np.ndarray], np.ndarray, np.ndarray, list[str]]`
+  returns aligned `u_list`, `v_list` (union order, zero-padded), pooled `ac`, `an`, `keys`.
+- `pooled_maf_weights(ac, an, scheme="beta:1,25") -> np.ndarray`
+
+Union = sorted set of keys across strata; each stratum's `U`/`V` embedded via index map
+(absent variant → zero row/col). Test: two strata with overlapping+disjoint keys align correctly;
+a variant present in one only contributes `U=0` in the other; pooled MAF `= ΣAC/ΣAN`.
+
+---
+
+### Task 4: Manifest + comparability/safety validation
+
+**Files:**
+- Create: `variantcentrifuge/association/meta/manifest.py`
+- Test: `tests/unit/test_meta_manifest.py`
+
+**Interfaces — Produces:**
+- `read_study_manifest(path) -> list[StratumRef]` (columns: `stratum_id, artifact_path`)
+- `validate_comparability(artifacts) -> None` — raises `MetaCompatibilityError` on mismatched
+  `genome_build` / `annotation_version` / `mask_hash`, or on sample-hash overlap across strata.
+
+Tests (acceptance #4, #5): build/annotation/mask mismatch → raises; overlapping `sample_id_hashes`
+→ raises; well-formed manifest → passes; missing artifact file → clear error.
+
+---
+
+### Task 5: Heterogeneity + leave-one-out
+
+**Files:**
+- Create: `variantcentrifuge/association/meta/heterogeneity.py`
+- Test: `tests/unit/test_meta_heterogeneity.py`
+
+**Interfaces — Produces:**
+- `cochran_q(betas, ses) -> tuple[float, float, float]`  (Q, p, I²)
+- `per_stratum_burden(u_list, v_list, w) -> tuple[np.ndarray, np.ndarray]`  (betas, ses)
+- `leave_one_out(u_list, v_list, w, combine_fn) -> list[tuple[str, float]]`
+
+Test (acceptance #1, #2): concordant strata → `meta_burden_p < min(stratum_p)`; opposite-direction
+strata → `het_p` significant while common-effect burden attenuated.
+
+---
+
+### Task 6: Runner + exome-wide multiplicity + output
+
+**Files:**
+- Create: `variantcentrifuge/association/meta/runner.py`
+- Test: `tests/unit/test_meta_runner.py`
+
+**Interfaces — Produces:**
+- `run_meta(manifest_path, output_path, weight_scheme, correction) -> pd.DataFrame`
+
+Per gene×mask: align → weights → burden/skat/skato → heterogeneity → LOO; per-gene omnibus across
+masks via ACAT (`cauchy_combination`); BH/Bonferroni across genes on the omnibus; write `meta.tsv`
+with the §8 schema. Test: 3-gene synthetic run produces the expected columns and a monotone qvalue.
+
+---
+
+### Task 7: CLI console_script
+
+**Files:**
+- Create: `variantcentrifuge/association/meta/cli.py`
+- Modify: `pyproject.toml` `[project.scripts]` → add `variantcentrifuge-meta = "variantcentrifuge.association.meta.cli:main"`
+- Test: `tests/unit/test_meta_cli.py`
+
+`main()` argparse: `--manifest`, `--output`, `--weights` (default `beta:1,25`),
+`--correction` (default `fdr`), `--log-level`. Reuses `run_meta`. Test invokes `main([...])` on a
+synthetic manifest and asserts the output TSV exists with correct header; safe-logging test
+(acceptance #6) asserts no sample IDs appear in output/logs.
+
+---
+
+### Task 8: Docs
+
+**Files:**
+- Create: `docs/source/guides/meta_analysis.md`
+- Modify: `docs/source/guides/association_testing.md` (cross-link; ACAT-O vs meta distinction)
+
+Explain the study manifest, artifact/output schema, weight harmonisation, the within-gene ACAT-O
+vs across-stratum meta distinction, the calibration workflow, and the documented severe-imbalance
+limitation (SPA deferred).
+
+## Self-Review
+
+- Spec §4 stats → Tasks 1,2,3. §5 safety → Tasks 3,4. §6 modules → Tasks 1–7. §8 output → Task 6.
+  §9 acceptance → Tasks 2,4,5,7. §10 deferred → docs (Task 8). All covered.
+- No placeholders; all load-bearing code shown. Signatures consistent across tasks
+  (`u_list`,`v_list`,`w`; `GeneScore`; `_skato_get_pvalue`).
+- Golden gate (Task 2) is the correctness anchor.

--- a/docs/superpowers/specs/2026-07-20-cohort-meta-analysis-design.md
+++ b/docs/superpowers/specs/2026-07-20-cohort-meta-analysis-design.md
@@ -1,0 +1,238 @@
+# Design — Cohort-stratified rare-variant score-statistic meta-analysis
+
+Issue: scholl-lab/variantcentrifuge#112
+Date: 2026-07-20
+Status: Design (autonomous execution under session goal directive)
+
+## 0. Provenance and scope decision
+
+This design was produced under an explicit session directive to brainstorm a spec
+and plan, adversarially review them, and implement end-to-end. The brainstorming
+skill's interactive per-section approval gate was executed autonomously (the user
+is the issue author and pre-authorised the workflow); every material decision is
+recorded here for audit.
+
+**Governance note (must be ratified by a maintainer).** `.planning/PROJECT.md`
+currently lists *"Meta-analysis (RAREMETAL, Meta-SAIGE)"* and *"Mixed model / GRM
+(SAIGE-GENE approach)"* as **Out of Scope**. This feature intentionally moves the
+first item in-scope and adds an *interface seam* (not an implementation) for the
+second. `PROJECT.md` must be updated to reflect the new scope. This is a
+deliberate scope change, not an oversight.
+
+## 1. Problem
+
+VariantCentrifuge is a single-cohort tool: one VCF, one case/control assignment,
+one phenotype vector, one null model, one output sidecar. It has a mature
+association engine (Fisher, logistic/linear burden with Firth fallback,
+pure-Python SKAT/SKAT-O, COAST, covariates/PCA, within-gene ACAT-O) but no way to
+combine two clinically distinct, potentially severely imbalanced case-control
+cohorts in one calibrated exome-wide rare-variant discovery analysis without
+either (a) pooling with a cohort covariate (ignores ascertainment/outcome/batch
+differences) or (b) combining per-gene p-values (loses signed score and covariance
+information needed for burden and kernel meta-analysis).
+
+## 2. Key enabling observation
+
+The sufficient statistics for score-statistic meta-analysis already exist
+transiently in the SKAT backend and are discarded:
+
+- `PythonSKATBackend._test_skat` computes `score_vec = (G∘W)ᵀ r` and eigenvalues
+  of the projection-adjusted covariance, then collapses to a p-value.
+- `NullModelResult.extra` carries `{residuals, sigma2, mu_hat, design_matrix}` —
+  everything needed to regenerate the per-gene score vector `U` and covariance `V`
+  for any variant set.
+
+`U` (length p) and `V` (p×p) are **gene-level aggregates** — no per-sample rows —
+so persisting them satisfies the issue's privacy non-goal directly. This feature
+is fundamentally: *stop discarding `U` and `V`, persist them per stratum, then
+combine*, reusing the existing Davies→saddlepoint→Liu chain and the existing
+SKAT-O omnibus integration unchanged.
+
+## 3. Terminology
+
+The word "cohort" already means "one case/control study population / an aggregated
+single-sample report" throughout the codebase. To avoid collision, this feature
+uses **stratum** (plural: strata) for a meta-analysis contributing study, and
+**study manifest** for the multi-stratum configuration.
+
+## 4. Statistical design (verified against existing code)
+
+For stratum `c`, with null residuals `r_c = y_c − μ̂_c` and the GLS projection
+`P_c = W_c − W_c X_c (X_cᵀ W_c X_c)⁻¹ X_cᵀ W_c` (binary: `W_c = diag(μ̂(1−μ̂))`;
+quantitative: `W_c = I/σ²`), and a per-gene genotype dosage matrix `G_c`
+(columns = union variants, aligned by canonical key, absent → zero column):
+
+- **Unweighted score** `U_c = G_cᵀ r_c` (length p).
+- **Unweighted projection-adjusted covariance** `V_c = Z̃_cᵀ Z̃_c` (p×p), where
+  `Z̃_c = φ⊙G_c − φ⊙X_c (X_cᵀ diag(φ²) X_c)⁻¹ X_cᵀ diag(φ²) G_c`, `φ = √diag(W_c)`.
+  This is exactly the unweighted form of the `z_adj` matrix in
+  `_compute_eigenvalues_filtered` / `_test_skato`.
+
+Artifacts store `U_c`, `V_c` **unweighted** plus per-variant `AC_c`, `AN_c`.
+Weights are harmonised at meta time from the **pooled** MAF
+`maf_j = (Σ_c AC_cj)/(Σ_c AN_cj)` via `Beta(maf; 1, 25)` (or the configured
+scheme), applied identically to every stratum. Rationale: cohort-specific MAF
+weights put `U_c`/`V_c` on incompatible scales; pooled-MAF harmonisation is the
+MetaSKAT convention.
+
+At meta time, with harmonised weights `w` over the union:
+`S = Σ_c diag(w) U_c` (weighted meta score), `Σ = Σ_c diag(w) V_c diag(w)`
+(weighted meta covariance). Then:
+
+- **Meta-SKAT:** `Q = ‖S‖²/2`, null `Q ~ Σ λ_i χ²₁` with `λ = eig(Σ/2)` →
+  `davies.compute_pvalue(Q, λ)`.
+- **Meta-burden (common effect):** `S_b = wᵀ Σ_c U_c`, `Var_b = wᵀ Σ_c V_c w`
+  (equivalently `1ᵀS`, `1ᵀΣ1`), `Z = S_b/√Var_b`, `p = 2·Φ̄(|Z|)`,
+  direction `= sign(S_b)`. This is the projection-adjusted score burden
+  (more rigorous than the legacy `_test_burden`, which omits covariate projection).
+- **Meta-SKAT-O:** factor `A = Σ/2 = BᵀB` (via `eigh`, dropping tiny/negative
+  eigenvalues); compute `q_rho[i] = ((1−ρ)‖S‖² + ρ(1ᵀS)²)/2`; call the existing
+  `_skato_get_pvalue(q_rho, B, RHO_GRID)`. This is exact because
+  `_skato_optimal_param` and `_skato_get_pvalue` depend on the per-sample matrix
+  **only through `A = z1ᵀz1`**; any `B` with `BᵀB = A` yields identical results.
+
+**Golden correctness gate:** a single-stratum meta MUST reproduce
+`_test_skat`/`_test_skato`/(projection-adjusted burden) p-values bit-for-bit
+(within numerical tolerance) for the same data and weights. This ties all new
+statistics to already-trusted code.
+
+**Heterogeneity:** per-stratum burden effect `β_c = (wᵀU_c)/(wᵀV_c w)`,
+`SE_c = 1/√(wᵀV_c w)`; Cochran's `Q = Σ (β_c−β̄)²/SE_c²`, `df = C−1`,
+`I² = max(0,(Q−df)/Q)`, `p_het = χ²_df.sf(Q)`. Leave-one-stratum-out re-runs the
+meta on each subset. An explicit, opt-in ACAT combination of per-stratum p-values
+is offered as a heterogeneity-robust **companion** (never a silent substitute for
+the score-based common-effect test).
+
+## 5. Comparability and safety (the "never silently pool" requirement)
+
+Each artifact records `genome_build`, an `annotation_version`, and a
+`mask_definition_hash`. The meta step **refuses** (hard error, no fallback) when
+strata disagree on build/annotation/mask hash. Additional checks:
+
+- Variant keys are canonicalised (`chrom:pos:ref:alt`, normalised, left-aligned).
+  Alignment is by exact key; allele orientation fixes burden sign.
+- MAC filtering is applied on the **pooled** count at meta time, never per stratum
+  (a variant monomorphic in one stratum correctly contributes `U=0`, zero `V`
+  block — it is kept, not dropped).
+- Cross-stratum **sample-ID overlap** is checked; overlap violates the additive
+  covariance assumption and is refused (issue non-goal: no shared controls). Only
+  hashed sample IDs are compared; raw IDs never enter artifacts or reports.
+- Artifacts and reports contain only aggregate quantities (`U`, `V`, `AC`, `AN`,
+  counts, convergence flags). No sample IDs, no phenotype rows. Enforced by test.
+
+## 6. Architecture (module boundaries, all ≤600 lines per LOC policy)
+
+New package `variantcentrifuge/association/meta/`:
+
+- `artifact.py` — `ScoreCovarianceArtifact` dataclass; `compute_gene_artifact()`
+  (builds `U`,`V`,`AC`,`AN` from a genotype matrix + `NullModelResult`, reusing
+  `PythonSKATBackend.fit_null_model`); `save_artifact()` / `load_artifact()`
+  (`.npz` arrays + JSON sidecar metadata; schema-versioned).
+- `align.py` — canonical variant keys; union/alignment of per-stratum `U`/`V` into
+  a shared variant space; pooled-MAF computation.
+- `combine.py` — `meta_burden()`, `meta_skat()`, `meta_skato()` on aligned
+  artifacts; imports `davies.compute_pvalue`, `_skato_get_pvalue`, `_SKATO_RHO_GRID`.
+- `heterogeneity.py` — Cochran Q, I², per-stratum direction, leave-one-out,
+  optional ACAT companion.
+- `manifest.py` — study-manifest reader/validator (extends the dormant
+  `helpers.read_sequencing_manifest`); comparability checks from §5.
+- `runner.py` — orchestrate: load artifacts → align per gene×mask → combine →
+  heterogeneity → wide-format results; exome-wide multiplicity (per-gene omnibus
+  across masks via ACAT, then BH/Bonferroni across genes).
+- `cli.py` — `variantcentrifuge-meta` console_script (new `[project.scripts]`
+  entry). No VCF, no external tools; consumes artifacts only.
+
+**Emission from the real pipeline** is a thin, later addition: an
+`--emit-score-artifact` flag whose stage handler calls
+`meta.artifact.compute_gene_artifact` on the per-gene matrices the association
+stage already builds. To respect the 600-line ceiling on the allowlisted
+`python_backend.py` (1132 lines), no code is added there; the meta package imports
+its public/module-level functions.
+
+## 7. Data flow
+
+Per stratum (existing pipeline + emit flag, or the `compute_gene_artifact` API):
+VCF → association stage → `{gene: (variant_keys, U, V, AC, AN, n_cases,
+n_controls, null_convergence)}` → `stratum.artifact.npz` + `.meta.json`.
+
+Meta (`variantcentrifuge-meta --manifest study.tsv --output meta.tsv`):
+manifest → load N artifacts → validate comparability → per gene: align union,
+pooled-MAF weights, `meta_burden`/`meta_skat`/`meta_skato`, heterogeneity, LOO →
+exome-wide correction → `meta.tsv` (+ optional per-stratum diagnostics).
+
+## 8. Output schema (`meta.tsv`)
+
+`gene, mask, n_strata, n_cases_total, n_controls_total, n_variants_union,
+meta_burden_p, meta_burden_beta, meta_burden_direction, meta_skat_p,
+meta_skato_p, meta_skato_rho, het_q, het_p, het_i2, per_stratum_directions,
+loo_min_p, primary_p, primary_q, status, warnings`. Machine-readable and
+reproducible from artifacts alone.
+
+## 9. Testing → acceptance-criteria mapping
+
+1. **Concordant effects gain evidence** — 2 strata, same-direction burden signal;
+   assert `meta_burden_p < min(stratum_p)`.
+2. **Opposite directions distinguishable** — common-effect burden attenuated while
+   `het_p` significant.
+3. **Highly imbalanced stratum** — null simulation (modest scale) checks calibration
+   with documented tolerance; stable failure reporting. The severe-imbalance
+   anti-conservatism of the normal/Davies approximation is **documented as a known
+   limitation** requiring the deferred SPA backend; the test asserts the honest
+   behaviour, not an over-claim.
+4. **Incompatible callability** — build/annotation/mask-hash mismatch → explicit
+   error, never silent pooling.
+5. **Config/alignment validation failures** — manifest errors and sample overlap → error.
+6. **Safe aggregate outputs** — artifact/report contain no sample IDs / phenotype rows.
+7. **Golden consistency** — single-stratum meta == `_test_skat`/`_test_skato`/burden.
+
+Independent cross-validation against MetaSKAT/seqMeta on shared synthetic data is
+recommended as a follow-up (R not guaranteed in CI; captured values are Python-native).
+
+## 10. Deferred (interface-ready, not implemented)
+
+- **Genotype-level SPA** (SAIGE-GENE style) for calibrated *severe*-imbalance
+  burden/ACAT-V tails. The artifact carries the raw `U`/`V`; an SPA meta path can
+  be added without schema change.
+- **GLMM/GRM null backend.** `V` is stored as a full matrix (not assumed diagonal),
+  so a relatedness-aware null (non-diagonal residual covariance) drops in without
+  reworking the schema.
+
+## 11. Non-goals (unchanged from issue)
+
+No phenotype harmonisation, no control borrowing, no external controls, no raw
+genotype/clinical upload, no claim that a pooled cohort covariate solves
+ascertainment/outcome differences.
+
+## 12. Revision 1 — corrections from adversarial (Codex, high-effort) review
+
+Each item below overrides earlier text where they conflict. All were verified
+against the math and the backend before acceptance.
+
+1. **Binary-only scope.** For Gaussian residuals `Var(G'r) = σ²·G'PG`, so the
+   §4 pairing `U=G'r`, `V=G'PG/σ²` is inconsistent for **quantitative** traits.
+   For **binary** traits `σ²=1` and `V=G'PG=Var(U)` exactly, so the design is
+   correct. This implementation is therefore **binary-only**;
+   `compute_gene_artifact`/`combine` raise `NotImplementedError` for quantitative,
+   which is deferred until a coherent likelihood-score convention is added.
+2. **Exact SKAT-O factorisation.** Factor `A=Σ/2` keeping **all non-negative**
+   eigenmodes (clip only round-off negatives to 0), so `BᵀB=A` exactly. The
+   per-rho `_get_lambda` filtering stays *inside* `_skato_get_pvalue`. (Earlier
+   plan Task 2 truncated positive modes — wrong.)
+3. **Raw allele counts.** `compute_gene_artifact` takes the **pre-imputation**
+   dosage (NaN=missing); `AN = 2·#non-missing`, `AC = nansum(raw)`. Never derive
+   `AC`/`AN` from the imputed matrix (imputation forces `AN=2N` and pollutes `AC`).
+4. **Real convergence.** Store `null_converged = bool(fit_result.converged)` from
+   statsmodels (not `bool(nm.extra)`, which is always true). The meta step
+   **excludes** non-converged strata with an explicit status and propagates the
+   Davies p-method/convergence flag into results.
+5. **Weight surface = Beta/uniform only.** Only pooled-frequency Beta and uniform
+   weights are reproducible from artifacts; CADD/REVEL/score-column schemes are
+   rejected with a clear error (would require persisting per-variant annotation
+   provenance — deferred).
+6. **ALT vs minor allele.** `ΣAC/ΣAN` is pooled **ALT** frequency; the Beta weight
+   uses `MAF = min(af, 1−af)`. Callers must apply rare-AF filtering upstream.
+7. **Heterogeneity df** = (strata with non-zero information) − 1. Manifest
+   validation additionally rejects **mixed trait types** across strata.
+8. Sample-hash non-overlap is checked but does **not** by itself establish
+   independence for related/shared-control populations — that remains an explicit
+   caller assumption (documented).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
 [project.scripts]
 variantcentrifuge = "variantcentrifuge.cli:main"
 variantcentrifuge-build-pm5 = "variantcentrifuge.build_pm5_lookup:main"
+variantcentrifuge-meta = "variantcentrifuge.association.meta.cli:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "variantcentrifuge.version.__version__"}

--- a/tests/unit/meta_helpers.py
+++ b/tests/unit/meta_helpers.py
@@ -1,0 +1,72 @@
+"""Synthetic-stratum builders for meta-analysis tests (not collected by pytest)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from variantcentrifuge.association.meta.artifact import (
+    ScoreCovarianceArtifact,
+    build_stratum_artifact,
+)
+
+
+def make_stratum(
+    stratum_id: str,
+    seed: int,
+    *,
+    gene_keys: dict[str, list[str]],
+    effect_gene: str | None = None,
+    effect_sign: float = 0.0,
+    effect_size: float = 1.2,
+    n: int = 600,
+    sample_prefix: str | None = None,
+    genome_build: str = "GRCh38",
+    annotation_version: str = "snpeff-5.1",
+    mask_id: str = "pLoF",
+    mask_hash: str = "hash-plof-v1",
+) -> ScoreCovarianceArtifact:
+    """Build a synthetic binary-trait stratum artifact.
+
+    ``gene_keys`` maps gene -> list of canonical variant keys. An optional
+    single-gene burden effect can be injected with a given sign.
+    """
+    rng = np.random.default_rng(seed)
+    all_keys = sorted({k for keys in gene_keys.values() for k in keys})
+    key_pos = {k: i for i, k in enumerate(all_keys)}
+    p_total = len(all_keys)
+    mafs = rng.uniform(0.01, 0.05, size=p_total)
+    geno_all = rng.binomial(2, mafs[np.newaxis, :], size=(n, p_total)).astype(np.float64)
+
+    cov = np.column_stack([rng.normal(size=n), rng.integers(0, 2, size=n).astype(float)])
+    logit = -1.6 + 0.25 * cov[:, 0]
+    if effect_gene is not None and effect_sign != 0.0:
+        cols = [key_pos[k] for k in gene_keys[effect_gene]]
+        burden = geno_all[:, cols].sum(axis=1)
+        scale = burden.std() or 1.0
+        logit = logit + effect_sign * effect_size * burden / scale
+    prob = 1.0 / (1.0 + np.exp(-logit))
+    y = (rng.uniform(size=n) < prob).astype(np.float64)
+
+    genes: dict[str, tuple[np.ndarray, np.ndarray, list[str]]] = {}
+    for gene, keys in gene_keys.items():
+        cols = [key_pos[k] for k in keys]
+        g = geno_all[:, cols]
+        genes[gene] = (g, g.copy(), list(keys))
+
+    prefix = sample_prefix if sample_prefix is not None else stratum_id
+    sample_hashes = [f"{prefix}_s{i}" for i in range(n)]
+
+    return build_stratum_artifact(
+        stratum_id=stratum_id,
+        genes=genes,
+        phenotype=y,
+        covariates=cov,
+        trait_type="binary",
+        genome_build=genome_build,
+        annotation_version=annotation_version,
+        mask_id=mask_id,
+        mask_hash=mask_hash,
+        n_cases=int(y.sum()),
+        n_controls=int((1 - y).sum()),
+        sample_id_hashes=sample_hashes,
+    )

--- a/tests/unit/test_meta_align.py
+++ b/tests/unit/test_meta_align.py
@@ -1,0 +1,57 @@
+"""Variant alignment and pooled-frequency weight harmonisation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from variantcentrifuge.association.meta.align import (
+    align_strata,
+    canonical_key,
+    pooled_frequency_weights,
+)
+from variantcentrifuge.association.meta.artifact import GeneScore
+
+
+def _gs(keys, u, ac, an):
+    p = len(keys)
+    return GeneScore(
+        keys, np.array(u, float), np.eye(p), np.array(ac, float), np.array(an, float), True
+    )
+
+
+def test_canonical_key_strips_chr_and_uppercases():
+    assert canonical_key("chr1", 100, "a", "g") == "1:100:A:G"
+    assert canonical_key("1", "100", "A", "G") == "1:100:A:G"
+
+
+def test_align_union_zero_pads_absent_variants():
+    a = _gs(["1:1:A:G", "1:2:A:G"], [3.0, 5.0], [3, 5], [200, 200])
+    b = _gs(["1:2:A:G", "1:3:A:G"], [7.0, 11.0], [7, 11], [300, 300])
+    u_list, v_list, ac, an, keys = align_strata([a, b])
+
+    assert keys == ["1:1:A:G", "1:2:A:G", "1:3:A:G"]
+    # Stratum A has no data for 1:3 -> zero score there; B none for 1:1.
+    np.testing.assert_allclose(u_list[0], [3.0, 5.0, 0.0])
+    np.testing.assert_allclose(u_list[1], [0.0, 7.0, 11.0])
+    # Pooled AC/AN summed on the shared variant only.
+    np.testing.assert_allclose(ac, [3.0, 12.0, 11.0])
+    np.testing.assert_allclose(an, [200.0, 500.0, 300.0])
+    # Covariance zero-block for absent variants.
+    assert v_list[0][2, 2] == 0.0
+    assert v_list[1][0, 0] == 0.0
+
+
+def test_pooled_beta_weight_uses_minor_allele_frequency():
+    # af = 0.9 -> maf = 0.1; weight equals Beta(0.1;1,25) pdf.
+    w = pooled_frequency_weights(np.array([180.0]), np.array([200.0]), "beta:1,25")
+    import scipy.stats
+
+    assert w[0] == pytest.approx(scipy.stats.beta.pdf(0.1, 1, 25))
+
+
+def test_uniform_weights_and_rejected_scheme():
+    w = pooled_frequency_weights(np.array([1.0, 2.0]), np.array([100.0, 100.0]), "uniform")
+    np.testing.assert_allclose(w, [1.0, 1.0])
+    with pytest.raises(ValueError, match="Unsupported meta weight scheme"):
+        pooled_frequency_weights(np.array([1.0]), np.array([100.0]), "cadd")

--- a/tests/unit/test_meta_artifact.py
+++ b/tests/unit/test_meta_artifact.py
@@ -1,0 +1,76 @@
+"""Artifact computation, round-trip, and safe-aggregate-output guarantee (#6)."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from tests.unit.meta_helpers import make_stratum
+from variantcentrifuge.association.backends.python_backend import PythonSKATBackend
+from variantcentrifuge.association.meta.artifact import (
+    compute_gene_score,
+    load_artifact,
+    save_artifact,
+)
+
+KEYS = {"GENEA": [f"1:{100 + j}:A:G" for j in range(8)]}
+
+
+def test_gene_score_shapes_symmetry_and_psd():
+    rng = np.random.default_rng(0)
+    n, p = 400, 8
+    geno = rng.binomial(2, 0.03, size=(n, p)).astype(float)
+    y = (rng.uniform(size=n) < 0.2).astype(float)
+    backend = PythonSKATBackend()
+    backend.detect_environment()
+    nm = backend.fit_null_model(phenotype=y, covariates=None, trait_type="binary")
+
+    gs = compute_gene_score(geno, geno, nm, list(KEYS["GENEA"]))
+    assert gs.u.shape == (p,)
+    assert gs.v.shape == (p, p)
+    np.testing.assert_allclose(gs.v, gs.v.T, atol=1e-10)
+    eigvals = np.linalg.eigvalsh(gs.v)
+    assert eigvals.min() > -1e-8  # positive semidefinite
+
+
+def test_ac_an_use_pre_imputation_dosage():
+    # Raw dosage has a missing call (NaN) that imputation would have filled.
+    raw = np.array([[0.0], [1.0], [np.nan], [2.0]])
+    imputed = np.array([[0.0], [1.0], [0.5], [2.0]])
+    backend = PythonSKATBackend()
+    backend.detect_environment()
+    y = np.array([0.0, 1.0, 0.0, 1.0])
+    nm = backend.fit_null_model(phenotype=y, covariates=None, trait_type="binary")
+    gs = compute_gene_score(imputed, raw, nm, ["1:1:A:G"])
+    # AN counts 3 observed samples (2 alleles each); AC excludes the imputed 0.5.
+    assert gs.an[0] == 6.0
+    assert gs.ac[0] == 3.0
+
+
+def test_save_load_round_trip(tmp_path):
+    art = make_stratum("A", seed=7, gene_keys=KEYS)
+    path = str(tmp_path / "stratumA")
+    save_artifact(art, path)
+    loaded = load_artifact(path)
+
+    assert loaded.stratum_id == art.stratum_id
+    assert loaded.mask_hash == art.mask_hash
+    gs0, gs1 = art.genes["GENEA"], loaded.genes["GENEA"]
+    np.testing.assert_allclose(gs0.u, gs1.u)
+    np.testing.assert_allclose(gs0.v, gs1.v)
+    assert gs1.variant_keys == gs0.variant_keys
+
+
+def test_artifact_sidecar_contains_only_safe_aggregates(tmp_path):
+    """Acceptance #6: no phenotype rows / raw sample IDs in the artifact metadata."""
+    art = make_stratum("A", seed=9, gene_keys=KEYS)
+    path = str(tmp_path / "stratumA")
+    save_artifact(art, path)
+    meta = json.loads((tmp_path / "stratumA.meta.json").read_text())
+
+    # Only hashed sample identifiers, counts, and aggregate keys — no phenotype values.
+    assert set(meta) >= {"n_cases", "n_controls", "sample_id_hashes", "genes"}
+    assert "phenotype" not in json.dumps(meta).lower()
+    # Sample hashes are opaque tokens, never real IDs with PII structure.
+    assert all(h.startswith("A_s") for h in meta["sample_id_hashes"])

--- a/tests/unit/test_meta_calibration.py
+++ b/tests/unit/test_meta_calibration.py
@@ -1,0 +1,101 @@
+"""Acceptance #3: null calibration under imbalance + stable degenerate-input handling.
+
+The common-effect score meta uses a normal/Davies approximation. It is well
+calibrated under MODERATE imbalance; SEVERE imbalance requires the deferred
+genotype-level saddlepoint (SPA) backend. These tests assert the honest,
+documented behaviour — gross calibration at moderate imbalance, and graceful
+failure (never a crash) for degenerate genes — not exact severe-imbalance tails.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from variantcentrifuge.association.meta.align import align_strata, pooled_frequency_weights
+from variantcentrifuge.association.meta.artifact import build_stratum_artifact
+from variantcentrifuge.association.meta.combine import meta_burden, meta_skat, meta_skato
+
+
+def _null_stratum(stratum_id, seed, n, prevalence, n_genes, p):
+    rng = np.random.default_rng(seed)
+    genes = {}
+    for gi in range(n_genes):
+        mafs = rng.uniform(0.02, 0.06, size=p)
+        g = rng.binomial(2, mafs[np.newaxis, :], size=(n, p)).astype(float)
+        genes[f"G{gi}"] = (g, g.copy(), [f"1:{gi * 100 + j}:A:G" for j in range(p)])
+    intercept = np.log(prevalence / (1 - prevalence))
+    y = (rng.uniform(size=n) < prevalence).astype(float)
+    _ = intercept  # prevalence-driven; no genotype effect (null)
+    return build_stratum_artifact(
+        stratum_id=stratum_id,
+        genes=genes,
+        phenotype=y,
+        covariates=None,
+        trait_type="binary",
+        genome_build="GRCh38",
+        annotation_version="v1",
+        mask_id="pLoF",
+        mask_hash="h1",
+        n_cases=int(y.sum()),
+        n_controls=int((1 - y).sum()),
+        sample_id_hashes=[f"{stratum_id}_{i}" for i in range(n)],
+    )
+
+
+def test_null_calibration_moderate_imbalance():
+    n_genes = 150
+    a = _null_stratum("A", seed=1, n=400, prevalence=0.12, n_genes=n_genes, p=8)
+    b = _null_stratum("B", seed=2, n=400, prevalence=0.12, n_genes=n_genes, p=8)
+
+    burden_ps, skat_ps = [], []
+    for gi in range(n_genes):
+        gene = f"G{gi}"
+        u_list, v_list, ac, an, _keys = align_strata([a.genes[gene], b.genes[gene]])
+        w = pooled_frequency_weights(ac, an, "beta:1,25")
+        bp, _beta, _d = meta_burden(u_list, v_list, w)
+        sp, _m = meta_skat(u_list, v_list, w)
+        if bp is not None:
+            burden_ps.append(bp)
+        if sp is not None:
+            skat_ps.append(sp)
+
+    burden_ps = np.array(burden_ps)
+    skat_ps = np.array(skat_ps)
+    # Gross calibration: mean near 0.5 and no severe type-I inflation at alpha=0.05.
+    assert 0.35 < burden_ps.mean() < 0.65
+    assert 0.35 < skat_ps.mean() < 0.65
+    assert (burden_ps < 0.05).mean() < 0.15
+    assert (skat_ps < 0.05).mean() < 0.15
+
+
+def test_monomorphic_gene_is_stable():
+    """A gene monomorphic in every stratum must not crash — it yields no signal."""
+    rng = np.random.default_rng(0)
+    n, p = 200, 5
+    zero = np.zeros((n, p))
+    y = (rng.uniform(size=n) < 0.2).astype(float)
+    keys = [f"1:{j}:A:G" for j in range(p)]
+    art = build_stratum_artifact(
+        stratum_id="A",
+        genes={"MONO": (zero, zero.copy(), keys)},
+        phenotype=y,
+        covariates=None,
+        trait_type="binary",
+        genome_build="GRCh38",
+        annotation_version="v1",
+        mask_id="pLoF",
+        mask_hash="h1",
+        n_cases=int(y.sum()),
+        n_controls=int((1 - y).sum()),
+        sample_id_hashes=[f"A_{i}" for i in range(n)],
+    )
+    u_list, v_list, ac, an, _keys = align_strata([art.genes["MONO"], art.genes["MONO"]])
+    w = pooled_frequency_weights(ac, an, "beta:1,25")
+
+    burden_p, _beta, direction = meta_burden(u_list, v_list, w)
+    skat_p, _method = meta_skat(u_list, v_list, w)
+    skato_p, _rho = meta_skato(u_list, v_list, w)
+
+    assert burden_p is None and direction == 0  # zero variance → undefined, not a crash
+    assert skat_p in (None, 1.0)
+    assert skato_p is None

--- a/tests/unit/test_meta_combine_golden.py
+++ b/tests/unit/test_meta_combine_golden.py
@@ -1,0 +1,88 @@
+"""Golden-gate tests: single-stratum meta must reproduce the trusted SKAT backend.
+
+If ``meta_skat``/``meta_skato`` on one stratum equal ``PythonSKATBackend._test_skat``/
+``_test_skato`` for the same data and weights, the meta score/covariance algebra is
+correct by construction. This ties all new statistics to already-validated code.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import scipy.stats
+
+from variantcentrifuge.association.backends.python_backend import PythonSKATBackend
+from variantcentrifuge.association.meta.artifact import compute_gene_score
+from variantcentrifuge.association.meta.combine import meta_burden, meta_skat, meta_skato
+
+
+def _synthetic_binary(seed: int, n: int = 500, p: int = 18, with_signal: bool = False):
+    """Return (G_imputed, y binary, X covariates, variant_keys) — no missingness."""
+    rng = np.random.default_rng(seed)
+    mafs = rng.uniform(0.01, 0.06, size=p)
+    geno = rng.binomial(2, mafs[np.newaxis, :], size=(n, p)).astype(np.float64)
+    # Two covariates (e.g. sex, one PC)
+    cov = np.column_stack([rng.normal(size=n), rng.integers(0, 2, size=n).astype(float)])
+    logit = -1.5 + 0.3 * cov[:, 0]
+    if with_signal:
+        logit = logit + 0.8 * geno.sum(axis=1) / max(1.0, geno.sum(axis=1).std())
+    prob = 1.0 / (1.0 + np.exp(-logit))
+    y = (rng.uniform(size=n) < prob).astype(np.float64)
+    keys = [f"1:{1000 + j}:A:G" for j in range(p)]
+    return geno, y, cov, keys
+
+
+def _fit(geno, y, cov):
+    backend = PythonSKATBackend()
+    backend.detect_environment()
+    null_model = backend.fit_null_model(phenotype=y, covariates=cov, trait_type="binary")
+    return backend, null_model
+
+
+@pytest.mark.parametrize("seed", [1, 7, 42])
+def test_meta_skat_matches_backend_single_stratum(seed):
+    geno, y, cov, keys = _synthetic_binary(seed)
+    backend, null_model = _fit(geno, y, cov)
+    weights = scipy.stats.beta.pdf(geno.mean(axis=0) / 2.0, 1.0, 25.0)
+
+    ref = backend.test_gene("GENE", geno, null_model, method="SKAT", weights=weights)
+    gs = compute_gene_score(geno, geno, null_model, keys)
+    meta_p, _method = meta_skat([gs.u], [gs.v], weights)
+
+    assert ref["p_value"] is not None and meta_p is not None
+    assert meta_p == pytest.approx(ref["p_value"], rel=1e-6, abs=1e-12)
+
+
+@pytest.mark.parametrize("seed", [2, 11, 43])
+def test_meta_skato_matches_backend_single_stratum(seed):
+    geno, y, cov, keys = _synthetic_binary(seed, with_signal=True)
+    backend, null_model = _fit(geno, y, cov)
+    weights = scipy.stats.beta.pdf(geno.mean(axis=0) / 2.0, 1.0, 25.0)
+
+    ref = backend.test_gene("GENE", geno, null_model, method="SKATO", weights=weights)
+    gs = compute_gene_score(geno, geno, null_model, keys)
+    meta_p, _rho = meta_skato([gs.u], [gs.v], weights)
+
+    assert ref["p_value"] is not None and meta_p is not None
+    # SKAT-O involves numerical integration; allow a slightly looser tolerance.
+    assert meta_p == pytest.approx(ref["p_value"], rel=1e-4, abs=1e-9)
+
+
+def test_meta_burden_matches_collapsed_skat():
+    """Burden (normal approx) must agree with SKAT on the single collapsed super-variant."""
+    geno, y, cov, keys = _synthetic_binary(seed=5, with_signal=True)
+    _backend, null_model = _fit(geno, y, cov)
+    weights = scipy.stats.beta.pdf(geno.mean(axis=0) / 2.0, 1.0, 25.0)
+
+    gs = compute_gene_score(geno, geno, null_model, keys)
+    burden_p, beta, direction = meta_burden([gs.u], [gs.v], weights)
+
+    # Collapse to a single weighted super-variant and run SKAT on it.
+    collapsed = (geno @ weights).reshape(-1, 1)
+    gs_c = compute_gene_score(collapsed, collapsed, null_model, ["1:1:A:G"])
+    skat_p, _method = meta_skat([gs_c.u], [gs_c.v], np.array([1.0]))
+
+    assert burden_p is not None and skat_p is not None
+    assert burden_p == pytest.approx(skat_p, rel=5e-3, abs=1e-6)
+    assert direction in (-1, 1)
+    assert np.isfinite(beta)

--- a/tests/unit/test_meta_heterogeneity.py
+++ b/tests/unit/test_meta_heterogeneity.py
@@ -1,0 +1,74 @@
+"""Heterogeneity + power acceptance criteria (#1 concordant, #2 opposite)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from tests.unit.meta_helpers import make_stratum
+from variantcentrifuge.association.meta.align import align_strata, pooled_frequency_weights
+from variantcentrifuge.association.meta.combine import meta_burden
+from variantcentrifuge.association.meta.heterogeneity import (
+    cochran_q,
+    leave_one_out,
+    per_stratum_burden,
+)
+
+GENE = "GENEA"
+KEYS = {GENE: [f"1:{100 + j}:A:G" for j in range(12)]}
+
+
+def _combine_two(art_a, art_b, scheme="beta:1,25"):
+    gs = [art_a.genes[GENE], art_b.genes[GENE]]
+    u_list, v_list, ac, an, _keys = align_strata(gs)
+    w = pooled_frequency_weights(ac, an, scheme)
+    return u_list, v_list, w
+
+
+def test_concordant_effects_gain_evidence():
+    """Acceptance #1: same-direction strata → meta beats either stratum alone."""
+    a = make_stratum("A", seed=101, gene_keys=KEYS, effect_gene=GENE, effect_sign=+1.0)
+    b = make_stratum("B", seed=202, gene_keys=KEYS, effect_gene=GENE, effect_sign=+1.0)
+
+    u_list, v_list, w = _combine_two(a, b)
+    meta_p, _beta, direction = meta_burden(u_list, v_list, w)
+    p_a, _, _ = meta_burden([u_list[0]], [v_list[0]], w)
+    p_b, _, _ = meta_burden([u_list[1]], [v_list[1]], w)
+
+    assert meta_p < min(p_a, p_b)
+    assert direction == 1
+
+
+def test_opposite_directions_are_distinguishable():
+    """Acceptance #2: opposite strata → common-effect attenuated, heterogeneity flagged."""
+    a = make_stratum(
+        "A", seed=303, gene_keys=KEYS, effect_gene=GENE, effect_sign=+1.0, effect_size=1.6
+    )
+    b = make_stratum(
+        "B", seed=404, gene_keys=KEYS, effect_gene=GENE, effect_sign=-1.0, effect_size=1.6
+    )
+
+    u_list, v_list, w = _combine_two(a, b)
+    burden_p, _beta, _direction = meta_burden(u_list, v_list, w)
+    betas, ses = per_stratum_burden(u_list, v_list, w)
+    _q, het_p, i2 = cochran_q(betas, ses)
+
+    # Opposite per-stratum directions and heterogeneity strictly more significant
+    # than the (cancelled) common-effect burden.
+    assert np.sign(betas[0]) != np.sign(betas[1])
+    assert het_p < burden_p
+    assert i2 > 0.5
+
+
+def test_leave_one_out_returns_per_stratum_dropped_pvalues():
+    a = make_stratum("A", seed=505, gene_keys=KEYS, effect_gene=GENE, effect_sign=+1.0)
+    b = make_stratum("B", seed=606, gene_keys=KEYS, effect_gene=GENE, effect_sign=+1.0)
+    u_list, v_list, w = _combine_two(a, b)
+    loo = leave_one_out(u_list, v_list, w, ["A", "B"], lambda u, v, ww: meta_burden(u, v, ww)[0])
+    assert [sid for sid, _p in loo] == ["A", "B"]
+    assert all(p is not None for _sid, p in loo)
+
+
+def test_cochran_q_df_uses_usable_strata_only():
+    # One stratum has zero information (SE inf) -> ignored; usable df collapses.
+    q, p, i2 = cochran_q(np.array([0.5, np.nan]), np.array([0.1, np.inf]))
+    assert (q, p, i2) == (0.0, 1.0, 0.0)

--- a/tests/unit/test_meta_manifest.py
+++ b/tests/unit/test_meta_manifest.py
@@ -1,0 +1,69 @@
+"""Manifest reading + comparability/safety validation (acceptance #4, #5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.meta_helpers import make_stratum
+from variantcentrifuge.association.meta.manifest import (
+    MetaCompatibilityError,
+    read_study_manifest,
+    validate_comparability,
+)
+
+KEYS = {"GENEA": [f"1:{100 + j}:A:G" for j in range(6)]}
+
+
+def _pair(**overrides_b):
+    a = make_stratum("A", seed=11, gene_keys=KEYS)
+    b = make_stratum("B", seed=22, gene_keys=KEYS, **overrides_b)
+    return a, b
+
+
+def test_comparable_strata_pass():
+    a, b = _pair()
+    validate_comparability([a, b])  # no raise
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"genome_build": "GRCh37"},
+        {"annotation_version": "vep-110"},
+        {"mask_hash": "different-hash"},
+    ],
+)
+def test_mismatched_metadata_refused(override):
+    """Acceptance #4: build/annotation/mask mismatch → explicit error, no pooling."""
+    a, b = _pair(**override)
+    with pytest.raises(MetaCompatibilityError, match="disagree on"):
+        validate_comparability([a, b])
+
+
+def test_sample_overlap_refused():
+    """Acceptance #5: shared samples across strata → refuse (independence violated)."""
+    a = make_stratum("A", seed=1, gene_keys=KEYS, sample_prefix="shared")
+    b = make_stratum("B", seed=2, gene_keys=KEYS, sample_prefix="shared")
+    with pytest.raises(MetaCompatibilityError, match="Sample overlap"):
+        validate_comparability([a, b])
+
+
+def test_mixed_trait_type_refused():
+    a, b = _pair()
+    object.__setattr__(b, "trait_type", "quantitative")
+    with pytest.raises(MetaCompatibilityError, match="trait_type"):
+        validate_comparability([a, b])
+
+
+def test_manifest_requires_two_strata(tmp_path):
+    m = tmp_path / "manifest.tsv"
+    m.write_text("stratum_id\tartifact_path\nA\t/tmp/a.npz\n")
+    with pytest.raises(MetaCompatibilityError, match="at least 2"):
+        read_study_manifest(str(m))
+
+
+def test_manifest_missing_columns(tmp_path):
+    m = tmp_path / "bad.tsv"
+    m.write_text("id\tpath\nA\tx\nB\ty\n")
+    with pytest.raises(MetaCompatibilityError, match="must have columns"):
+        read_study_manifest(str(m))

--- a/tests/unit/test_meta_runner_cli.py
+++ b/tests/unit/test_meta_runner_cli.py
@@ -1,0 +1,76 @@
+"""End-to-end runner + CLI: manifest → meta TSV, and refusal paths."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from tests.unit.meta_helpers import make_stratum
+from variantcentrifuge.association.meta.artifact import save_artifact
+from variantcentrifuge.association.meta.cli import main
+from variantcentrifuge.association.meta.runner import OUTPUT_COLUMNS, run_meta
+
+GENE_KEYS = {
+    "SIG": [f"1:{100 + j}:A:G" for j in range(14)],
+    "NULLG": [f"2:{100 + j}:A:G" for j in range(10)],
+}
+
+
+def _write_study(tmp_path, effect_signs=(+1.0, +1.0), **compat):
+    a = make_stratum(
+        "A", seed=1, gene_keys=GENE_KEYS, effect_gene="SIG", effect_sign=effect_signs[0], **compat
+    )
+    b = make_stratum(
+        "B", seed=2, gene_keys=GENE_KEYS, effect_gene="SIG", effect_sign=effect_signs[1]
+    )
+    pa, pb = str(tmp_path / "A"), str(tmp_path / "B")
+    save_artifact(a, pa)
+    save_artifact(b, pb)
+    manifest = tmp_path / "study.tsv"
+    manifest.write_text(f"stratum_id\tartifact_path\nA\t{pa}\nB\t{pb}\n")
+    return str(manifest)
+
+
+def test_run_meta_produces_expected_schema_and_correction(tmp_path):
+    manifest = _write_study(tmp_path)
+    out = str(tmp_path / "meta.tsv")
+    df = run_meta(manifest, out, weight_scheme="beta:1,25", correction="fdr")
+
+    assert list(df.columns) == OUTPUT_COLUMNS
+    assert set(df["gene"]) == {"SIG", "NULLG"}
+    on_disk = pd.read_csv(out, sep="\t")
+    assert len(on_disk) == 2
+    # Every tested gene carries n_strata=2 and an "ok" status.
+    assert (df.loc[df["primary_p"].notna(), "n_strata"] == 2).all()
+    assert set(df.loc[df["primary_p"].notna(), "status"]) <= {"ok"}
+    # q-values are valid probabilities.
+    q = df["primary_q"].dropna()
+    assert ((q >= 0) & (q <= 1)).all()
+
+
+def test_run_meta_detects_concordant_signal(tmp_path):
+    manifest = _write_study(tmp_path, effect_signs=(+1.0, +1.0))
+    out = str(tmp_path / "meta.tsv")
+    df = run_meta(manifest, out).set_index("gene")
+    # The signal gene is more significant than the null gene.
+    assert df.loc["SIG", "primary_p"] < df.loc["NULLG", "primary_p"]
+
+
+def test_cli_main_success(tmp_path):
+    manifest = _write_study(tmp_path)
+    out = str(tmp_path / "meta.tsv")
+    rc = main(["--manifest", manifest, "--output", out, "--weights", "beta:1,25"])
+    assert rc == 0
+    assert (tmp_path / "meta.tsv").exists()
+
+
+def test_cli_refuses_incomparable_strata(tmp_path):
+    # Stratum B built on a different genome build -> comparability refusal (exit 2).
+    a = make_stratum("A", seed=1, gene_keys=GENE_KEYS)
+    b = make_stratum("B", seed=2, gene_keys=GENE_KEYS, genome_build="GRCh37")
+    pa, pb = str(tmp_path / "A"), str(tmp_path / "B")
+    save_artifact(a, pa)
+    save_artifact(b, pb)
+    manifest = tmp_path / "study.tsv"
+    manifest.write_text(f"stratum_id\tartifact_path\nA\t{pa}\nB\t{pb}\n")
+    rc = main(["--manifest", str(manifest), "--output", str(tmp_path / "out.tsv")])
+    assert rc == 2

--- a/variantcentrifuge/association/meta/__init__.py
+++ b/variantcentrifuge/association/meta/__init__.py
@@ -1,0 +1,41 @@
+# File: variantcentrifuge/association/meta/__init__.py
+"""
+Cohort-stratified rare-variant score-statistic meta-analysis (issue #112).
+
+Combines per-stratum score/covariance artifacts (burden, SKAT, SKAT-O) computed
+by the existing single-cohort association engine into a common-effect meta-analysis
+with heterogeneity diagnostics. Binary traits only (quantitative deferred; see the
+design spec revision 1). Reuses the Davies chain and SKAT-O omnibus in
+``association.backends`` — nothing is reimplemented that already exists.
+
+Public surface
+--------------
+- ``ScoreCovarianceArtifact`` / ``GeneScore`` — the persisted aggregate artifact.
+- ``compute_gene_score`` / ``fit_stratum_null`` — build score/covariance per gene.
+- ``meta_burden`` / ``meta_skat`` / ``meta_skato`` — combine aligned strata.
+- ``run_meta`` — end-to-end manifest → meta results TSV.
+"""
+
+from __future__ import annotations
+
+from variantcentrifuge.association.meta.artifact import (
+    GeneScore,
+    ScoreCovarianceArtifact,
+    compute_gene_score,
+    fit_stratum_null,
+    load_artifact,
+    save_artifact,
+)
+from variantcentrifuge.association.meta.combine import meta_burden, meta_skat, meta_skato
+
+__all__ = [
+    "GeneScore",
+    "ScoreCovarianceArtifact",
+    "compute_gene_score",
+    "fit_stratum_null",
+    "load_artifact",
+    "meta_burden",
+    "meta_skat",
+    "meta_skato",
+    "save_artifact",
+]

--- a/variantcentrifuge/association/meta/align.py
+++ b/variantcentrifuge/association/meta/align.py
@@ -1,0 +1,113 @@
+# File: variantcentrifuge/association/meta/align.py
+"""
+Variant alignment across strata and pooled-frequency weight harmonisation.
+
+Two strata sequenced/called separately observe different variant sets within a
+gene. Meta-analysis takes the union of variants (by canonical key) and embeds each
+stratum's score ``U`` and covariance ``V`` into that union space, with zeros for
+variants a stratum did not observe (a variant monomorphic in one stratum
+correctly contributes no information there — it is kept, never dropped).
+
+Weights are harmonised once from the POOLED ALT-allele frequency ``ΣAC/ΣAN`` so
+every stratum uses the same per-variant weight (cohort-specific MAF weights would
+put ``U``/``V`` on incompatible scales). The Beta weight uses ``MAF=min(af,1-af)``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import scipy.stats
+
+from variantcentrifuge.association.meta.artifact import GeneScore
+
+logger = logging.getLogger("variantcentrifuge")
+
+
+def canonical_key(chrom: str, pos: int | str, ref: str, alt: str) -> str:
+    """Canonical variant key ``chrom:pos:ref:alt`` (chrom normalised, alleles upper).
+
+    Strips a leading ``chr`` prefix so ``chr1`` and ``1`` align. Alleles are
+    upper-cased. Callers are responsible for prior normalisation/left-alignment.
+    """
+    c = str(chrom)
+    if c.lower().startswith("chr"):
+        c = c[3:]
+    return f"{c}:{int(pos)}:{str(ref).upper()}:{str(alt).upper()}"
+
+
+def align_strata(
+    gene_scores: list[GeneScore],
+) -> tuple[list[np.ndarray], list[np.ndarray], np.ndarray, np.ndarray, list[str]]:
+    """Embed each stratum's ``U``/``V`` into the shared union of variant keys.
+
+    Returns
+    -------
+    (u_list, v_list, ac_pooled, an_pooled, union_keys)
+        ``u_list[c]`` has shape (m,), ``v_list[c]`` shape (m, m) where m = |union|;
+        ``ac_pooled``/``an_pooled`` are summed across strata (shape (m,)).
+    """
+    if not gene_scores:
+        raise ValueError("align_strata requires at least one GeneScore")
+
+    union_keys = sorted({k for gs in gene_scores for k in gs.variant_keys})
+    index = {k: i for i, k in enumerate(union_keys)}
+    m = len(union_keys)
+
+    u_list: list[np.ndarray] = []
+    v_list: list[np.ndarray] = []
+    ac_pooled = np.zeros(m, dtype=np.float64)
+    an_pooled = np.zeros(m, dtype=np.float64)
+
+    for gs in gene_scores:
+        cols = np.array([index[k] for k in gs.variant_keys], dtype=int)
+        u_full = np.zeros(m, dtype=np.float64)
+        v_full = np.zeros((m, m), dtype=np.float64)
+        u_full[cols] = gs.u
+        v_full[np.ix_(cols, cols)] = gs.v
+        u_list.append(u_full)
+        v_list.append(v_full)
+        ac_pooled[cols] += gs.ac
+        an_pooled[cols] += gs.an
+
+    return u_list, v_list, ac_pooled, an_pooled, union_keys
+
+
+def pooled_frequency_weights(
+    ac_pooled: np.ndarray,
+    an_pooled: np.ndarray,
+    scheme: str = "beta:1,25",
+) -> np.ndarray:
+    """Harmonised per-variant weights from pooled frequency.
+
+    Only ``beta:a,b`` and ``uniform`` are supported — the only schemes reproducible
+    from the persisted artifacts. CADD/REVEL/score-column schemes are rejected
+    (they need per-variant annotation provenance not stored in the artifact).
+    """
+    ac = np.asarray(ac_pooled, dtype=np.float64)
+    an = np.asarray(an_pooled, dtype=np.float64)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        af = np.where(an > 0, ac / an, 0.0)
+    maf = np.minimum(af, 1.0 - af)
+
+    scheme = scheme.strip().lower()
+    if scheme == "uniform":
+        return np.ones_like(maf)
+    if scheme.startswith("beta:"):
+        try:
+            a_str, b_str = scheme.split(":", 1)[1].split(",")
+            a, b = float(a_str), float(b_str)
+        except ValueError as exc:
+            raise ValueError(
+                f"Malformed beta weight scheme '{scheme}' (expected beta:a,b)"
+            ) from exc
+        return np.asarray(scipy.stats.beta.pdf(maf, a, b), dtype=np.float64)
+    raise ValueError(
+        f"Unsupported meta weight scheme '{scheme}'. Meta-analysis supports only "
+        "'beta:a,b' and 'uniform' (functional-score weights are not reproducible "
+        "from score artifacts)."
+    )
+
+
+__all__ = ["align_strata", "canonical_key", "pooled_frequency_weights"]

--- a/variantcentrifuge/association/meta/artifact.py
+++ b/variantcentrifuge/association/meta/artifact.py
@@ -1,0 +1,284 @@
+# File: variantcentrifuge/association/meta/artifact.py
+"""
+Score/covariance artifact schema and gene-level computation for meta-analysis.
+
+Per stratum we persist, for every gene, the unweighted score vector ``U = Gᵀr``
+and the projection-adjusted covariance ``V = Gᵀ P G`` (the same quantity SKAT
+computes internally, before weighting), plus per-variant observed ALT-allele
+counts ``AC`` and allele numbers ``AN``. These are gene-level aggregates: no
+per-sample rows and no phenotype values are ever stored, so artifacts are safe to
+share (issue #112 privacy non-goal).
+
+Binary traits only. For Gaussian residuals ``Var(Gᵀr) = σ²·GᵀPG`` so the
+``U``/``V`` pairing here is coherent only when ``σ²=1`` (binary). Quantitative
+support is deferred (spec revision 1).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+
+logger = logging.getLogger("variantcentrifuge")
+
+SCHEMA_VERSION = 1
+
+
+@dataclass
+class GeneScore:
+    """Aggregate score/covariance for one gene in one stratum.
+
+    Fields
+    ------
+    variant_keys : list[str]
+        Canonical ``chrom:pos:ref:alt`` keys, one per column of ``u``/``v``.
+    u : np.ndarray, shape (p,)
+        Unweighted score vector ``Gᵀ r`` (r = null residuals).
+    v : np.ndarray, shape (p, p)
+        Unweighted projection-adjusted covariance ``Gᵀ P G`` (== Var(u) for binary).
+    ac : np.ndarray, shape (p,)
+        Observed ALT-allele counts (pre-imputation).
+    an : np.ndarray, shape (p,)
+        Observed allele numbers = 2 * non-missing samples (pre-imputation).
+    null_converged : bool
+        Whether the stratum null model converged.
+    """
+
+    variant_keys: list[str]
+    u: np.ndarray
+    v: np.ndarray
+    ac: np.ndarray
+    an: np.ndarray
+    null_converged: bool
+
+
+@dataclass
+class ScoreCovarianceArtifact:
+    """A stratum's meta-analysis artifact: metadata + per-gene scores."""
+
+    stratum_id: str
+    genome_build: str
+    annotation_version: str
+    mask_id: str
+    mask_hash: str
+    trait_type: str
+    n_cases: int
+    n_controls: int
+    sample_id_hashes: list[str]
+    genes: dict[str, GeneScore]
+    schema_version: int = SCHEMA_VERSION
+
+
+def fit_stratum_null(
+    phenotype: np.ndarray,
+    covariates: np.ndarray | None,
+    trait_type: str,
+):
+    """Fit the stratum null model once (binary only), returning a NullModelResult.
+
+    Raises
+    ------
+    NotImplementedError
+        For non-binary traits (quantitative meta is deferred; spec revision 1).
+    """
+    if trait_type != "binary":
+        raise NotImplementedError(
+            "Meta-analysis currently supports binary traits only "
+            "(quantitative deferred pending a coherent likelihood-score convention)."
+        )
+    from variantcentrifuge.association.backends.python_backend import PythonSKATBackend
+
+    backend = PythonSKATBackend()
+    backend.detect_environment()
+    return backend.fit_null_model(phenotype=phenotype, covariates=covariates, trait_type=trait_type)
+
+
+def _null_converged(null_model) -> bool:
+    """Best-effort statsmodels convergence flag (NOT bool(extra), which is always true)."""
+    model = null_model.model
+    converged = getattr(model, "converged", None)
+    if converged is None:
+        retvals = getattr(model, "mle_retvals", None)
+        if isinstance(retvals, dict):
+            converged = retvals.get("converged", True)
+    return bool(True if converged is None else converged)
+
+
+def compute_gene_score(
+    genotype_matrix: np.ndarray,
+    raw_dosage: np.ndarray,
+    null_model,
+    variant_keys: list[str],
+) -> GeneScore:
+    """Compute the unweighted score vector and projection-adjusted covariance.
+
+    Parameters
+    ----------
+    genotype_matrix : np.ndarray, shape (n_samples, p)
+        Imputed dosage matrix (no NaN) — used for the score/covariance.
+    raw_dosage : np.ndarray, shape (n_samples, p)
+        Pre-imputation dosage (NaN = missing) — used only for AC/AN.
+    null_model : NullModelResult
+        From :func:`fit_stratum_null` (binary).
+    variant_keys : list[str]
+        Canonical keys aligned to the columns of ``genotype_matrix``.
+
+    Returns
+    -------
+    GeneScore
+    """
+    geno = np.asarray(genotype_matrix, dtype=np.float64)
+    if geno.ndim != 2:
+        raise ValueError("genotype_matrix must be 2-D (n_samples, p)")
+    _n_samples, p = geno.shape
+    if len(variant_keys) != p:
+        raise ValueError(f"variant_keys length {len(variant_keys)} != n_variants {p}")
+
+    residuals = np.asarray(null_model.extra["residuals"], dtype=np.float64)
+    design_x = np.asarray(null_model.extra["design_matrix"], dtype=np.float64)
+
+    # Unweighted score U = Gᵀ r
+    u = geno.T @ residuals
+
+    # Projection-adjusted covariance V = Gᵀ P G (binary form, matches _test_skato)
+    mu_hat = np.asarray(null_model.extra["mu_hat"], dtype=np.float64)
+    pi_1 = mu_hat * (1.0 - mu_hat)
+    phi = np.sqrt(pi_1)
+    z_phi = phi[:, np.newaxis] * geno
+    x_phi = phi[:, np.newaxis] * design_x
+    x_pi = pi_1[:, np.newaxis] * design_x
+    # z_adj = phi*G - phi*X (X' diag(pi) X)^-1 (X' diag(pi) G)  [projection-adjusted]
+    z_adj = z_phi - x_phi @ np.linalg.solve(x_phi.T @ x_phi, x_pi.T @ geno)
+    v = z_adj.T @ z_adj
+    v = 0.5 * (v + v.T)  # enforce exact symmetry against round-off
+
+    # AC/AN from the PRE-IMPUTATION dosage (never the imputed matrix)
+    raw = np.asarray(raw_dosage, dtype=np.float64)
+    if raw.shape != geno.shape:
+        raise ValueError("raw_dosage must have the same shape as genotype_matrix")
+    observed = ~np.isnan(raw)
+    an = 2.0 * observed.sum(axis=0).astype(np.float64)
+    ac = np.where(observed, raw, 0.0).sum(axis=0)
+
+    return GeneScore(
+        variant_keys=list(variant_keys),
+        u=u,
+        v=v,
+        ac=ac,
+        an=an,
+        null_converged=_null_converged(null_model),
+    )
+
+
+def build_stratum_artifact(
+    stratum_id: str,
+    genes: dict[str, tuple[np.ndarray, np.ndarray, list[str]]],
+    phenotype: np.ndarray,
+    covariates: np.ndarray | None,
+    trait_type: str,
+    *,
+    genome_build: str,
+    annotation_version: str,
+    mask_id: str,
+    mask_hash: str,
+    n_cases: int,
+    n_controls: int,
+    sample_id_hashes: list[str] | None = None,
+) -> ScoreCovarianceArtifact:
+    """Fit the null once and compute a GeneScore for every gene.
+
+    ``genes`` maps gene -> (imputed_matrix, raw_dosage, variant_keys).
+    """
+    null_model = fit_stratum_null(phenotype, covariates, trait_type)
+    gene_scores: dict[str, GeneScore] = {}
+    for gene, (imputed, raw, keys) in genes.items():
+        gene_scores[gene] = compute_gene_score(imputed, raw, null_model, keys)
+    return ScoreCovarianceArtifact(
+        stratum_id=stratum_id,
+        genome_build=genome_build,
+        annotation_version=annotation_version,
+        mask_id=mask_id,
+        mask_hash=mask_hash,
+        trait_type=trait_type,
+        n_cases=int(n_cases),
+        n_controls=int(n_controls),
+        sample_id_hashes=list(sample_id_hashes or []),
+        genes=gene_scores,
+    )
+
+
+def save_artifact(artifact: ScoreCovarianceArtifact, path: str) -> None:
+    """Serialise to ``<path>`` (arrays, .npz) + ``<path>.meta.json`` (metadata)."""
+    arrays: dict[str, np.ndarray] = {}
+    gene_meta: dict[str, dict] = {}
+    for gene, gs in artifact.genes.items():
+        arrays[f"{gene}::u"] = gs.u
+        arrays[f"{gene}::v"] = gs.v
+        arrays[f"{gene}::ac"] = gs.ac
+        arrays[f"{gene}::an"] = gs.an
+        gene_meta[gene] = {
+            "variant_keys": gs.variant_keys,
+            "null_converged": gs.null_converged,
+        }
+    np.savez_compressed(path, **arrays)  # type: ignore[arg-type]
+    meta = {
+        "schema_version": artifact.schema_version,
+        "stratum_id": artifact.stratum_id,
+        "genome_build": artifact.genome_build,
+        "annotation_version": artifact.annotation_version,
+        "mask_id": artifact.mask_id,
+        "mask_hash": artifact.mask_hash,
+        "trait_type": artifact.trait_type,
+        "n_cases": artifact.n_cases,
+        "n_controls": artifact.n_controls,
+        "sample_id_hashes": artifact.sample_id_hashes,
+        "genes": gene_meta,
+    }
+    with open(f"{path}.meta.json", "w", encoding="utf-8") as fh:
+        json.dump(meta, fh, indent=2)
+
+
+def load_artifact(path: str) -> ScoreCovarianceArtifact:
+    """Load an artifact written by :func:`save_artifact`."""
+    with open(f"{path}.meta.json", encoding="utf-8") as fh:
+        meta = json.load(fh)
+    npz_path = path if path.endswith(".npz") else f"{path}.npz"
+    with np.load(npz_path) as data:
+        genes: dict[str, GeneScore] = {}
+        for gene, gmeta in meta["genes"].items():
+            genes[gene] = GeneScore(
+                variant_keys=list(gmeta["variant_keys"]),
+                u=data[f"{gene}::u"],
+                v=data[f"{gene}::v"],
+                ac=data[f"{gene}::ac"],
+                an=data[f"{gene}::an"],
+                null_converged=bool(gmeta["null_converged"]),
+            )
+    return ScoreCovarianceArtifact(
+        stratum_id=meta["stratum_id"],
+        genome_build=meta["genome_build"],
+        annotation_version=meta["annotation_version"],
+        mask_id=meta["mask_id"],
+        mask_hash=meta["mask_hash"],
+        trait_type=meta["trait_type"],
+        n_cases=int(meta["n_cases"]),
+        n_controls=int(meta["n_controls"]),
+        sample_id_hashes=list(meta["sample_id_hashes"]),
+        genes=genes,
+        schema_version=int(meta["schema_version"]),
+    )
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "GeneScore",
+    "ScoreCovarianceArtifact",
+    "build_stratum_artifact",
+    "compute_gene_score",
+    "fit_stratum_null",
+    "load_artifact",
+    "save_artifact",
+]

--- a/variantcentrifuge/association/meta/cli.py
+++ b/variantcentrifuge/association/meta/cli.py
@@ -1,0 +1,86 @@
+# File: variantcentrifuge/association/meta/cli.py
+"""
+``variantcentrifuge-meta`` console entry point.
+
+Consumes pre-computed per-stratum score/covariance artifacts (no VCF, no external
+tools) and writes a meta-analysis results TSV. This mirrors the RAREMETAL /
+MetaSKAT / seqMeta pattern: per-study score files + a separate meta step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+logger = logging.getLogger("variantcentrifuge")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Argument parser for the meta-analysis CLI."""
+    parser = argparse.ArgumentParser(
+        prog="variantcentrifuge-meta",
+        description=(
+            "Cohort-stratified rare-variant score-statistic meta-analysis. "
+            "Combines per-stratum score/covariance artifacts (binary traits)."
+        ),
+    )
+    parser.add_argument(
+        "--manifest", required=True, help="Study manifest TSV (stratum_id, artifact_path)."
+    )
+    parser.add_argument("--output", required=True, help="Output meta results TSV path.")
+    parser.add_argument(
+        "--weights",
+        default="beta:1,25",
+        help="Weight scheme: 'beta:a,b' (default beta:1,25) or 'uniform'.",
+    )
+    parser.add_argument(
+        "--correction",
+        default="fdr",
+        choices=["fdr", "bonferroni"],
+        help="Multiple-testing correction across genes (default: fdr).",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging verbosity (default: INFO).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns a process exit code."""
+    args = build_parser().parse_args(argv)
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        stream=sys.stderr,
+    )
+
+    # Import here so --help stays fast and import errors surface at run time.
+    from variantcentrifuge.association.meta.manifest import MetaCompatibilityError
+    from variantcentrifuge.association.meta.runner import run_meta
+
+    try:
+        df = run_meta(
+            manifest_path=args.manifest,
+            output_path=args.output,
+            weight_scheme=args.weights,
+            correction=args.correction,
+        )
+    except MetaCompatibilityError as exc:
+        logger.error("Meta-analysis refused (strata not comparable): %s", exc)
+        return 2
+    except (FileNotFoundError, ValueError) as exc:
+        logger.error("Meta-analysis failed: %s", exc)
+        return 1
+
+    logger.info("Meta-analysis wrote %d gene rows to %s", len(df), args.output)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/variantcentrifuge/association/meta/combine.py
+++ b/variantcentrifuge/association/meta/combine.py
@@ -1,0 +1,138 @@
+# File: variantcentrifuge/association/meta/combine.py
+"""
+Common-effect meta-analysis of aligned per-stratum score/covariance statistics.
+
+Given per-stratum unweighted score vectors ``U_c`` and projection-adjusted
+covariances ``V_c`` (already aligned to a shared union of variants, zero-padded
+for variants absent in a stratum) and a single harmonised weight vector ``w``:
+
+    S = Σ_c diag(w) U_c            (weighted meta score)
+    Σ = Σ_c diag(w) V_c diag(w)    (weighted meta covariance)
+
+- meta-burden : Z = 1ᵀS / sqrt(1ᵀΣ1)
+- meta-SKAT   : Q = ‖S‖²/2, null Q ~ Σ λ_i χ²₁, λ = eig(Σ/2)  (Davies chain)
+- meta-SKAT-O : factor Σ/2 = BᵀB exactly, reuse the existing SKAT-O omnibus.
+
+A single-stratum call reproduces ``PythonSKATBackend._test_skat`` /
+``_test_skato`` / the projection-adjusted burden score test bit-for-bit (golden
+gate), because these formulas are the exact weighted forms of what the backend
+computes internally.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import scipy.linalg
+import scipy.stats
+
+from variantcentrifuge.association.backends.davies import compute_pvalue
+from variantcentrifuge.association.backends.python_backend import (
+    _SKATO_RHO_GRID,
+    _skato_get_pvalue,
+)
+
+logger = logging.getLogger("variantcentrifuge")
+
+# Matches R SKAT / _get_lambda eigenvalue-retention threshold.
+_LAMBDA_REL_THRESHOLD = 100_000.0
+
+
+def _weighted_moments(
+    u_list: list[np.ndarray],
+    v_list: list[np.ndarray],
+    weights: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return the weighted meta score S and weighted meta covariance Σ."""
+    w = np.asarray(weights, dtype=np.float64)
+    s = np.zeros_like(w)
+    sigma = np.zeros((w.size, w.size), dtype=np.float64)
+    for u, v in zip(u_list, v_list, strict=True):
+        s += w * np.asarray(u, dtype=np.float64)
+        sigma += (w[:, np.newaxis] * np.asarray(v, dtype=np.float64)) * w[np.newaxis, :]
+    sigma = 0.5 * (sigma + sigma.T)
+    return s, sigma
+
+
+def _filter_lambdas(mat: np.ndarray) -> np.ndarray:
+    """Eigenvalues of a symmetric matrix, kept per R SKAT (mean(pos)/1e5) threshold."""
+    lam = scipy.linalg.eigh(mat, eigvals_only=True, driver="evr")
+    pos = lam[lam >= 0]
+    if pos.size == 0:
+        return np.array([], dtype=np.float64)
+    return np.asarray(lam[lam > pos.mean() / _LAMBDA_REL_THRESHOLD], dtype=np.float64)
+
+
+def meta_skat(
+    u_list: list[np.ndarray],
+    v_list: list[np.ndarray],
+    weights: np.ndarray,
+) -> tuple[float | None, str]:
+    """Meta-SKAT p-value. Returns (p_value, p_method); p_value None if untestable."""
+    s, sigma = _weighted_moments(u_list, v_list, weights)
+    q = float(s @ s) / 2.0
+    lambdas = _filter_lambdas(sigma / 2.0)
+    if lambdas.size == 0:
+        return 1.0, "degenerate"
+    p, method, _converged = compute_pvalue(q, lambdas)
+    if not np.isfinite(p):
+        return None, method
+    return float(np.clip(p, 0.0, 1.0)), method
+
+
+def meta_burden(
+    u_list: list[np.ndarray],
+    v_list: list[np.ndarray],
+    weights: np.ndarray,
+) -> tuple[float | None, float, int]:
+    """Common-effect burden meta. Returns (p_value, beta, direction).
+
+    ``beta`` is the score-based effect estimate S_b / Var_b; ``direction`` is its
+    sign (+1 risk, -1 protective, 0 undefined).
+    """
+    s, sigma = _weighted_moments(u_list, v_list, weights)
+    score = float(s.sum())
+    var = float(sigma.sum())
+    if var <= 0.0:
+        return None, 0.0, 0
+    z = score / np.sqrt(var)
+    p = float(2.0 * scipy.stats.norm.sf(abs(z)))
+    beta = score / var
+    return p, beta, int(np.sign(score))
+
+
+def meta_skato(
+    u_list: list[np.ndarray],
+    v_list: list[np.ndarray],
+    weights: np.ndarray,
+) -> tuple[float | None, float | None]:
+    """Meta-SKAT-O omnibus p-value. Returns (p_value, optimal_rho)."""
+    s, sigma = _weighted_moments(u_list, v_list, weights)
+    a_mat = sigma / 2.0
+
+    # Exact factor B with BᵀB = A: keep ALL non-negative eigenmodes (clip round-off).
+    eigvals, eigvecs = scipy.linalg.eigh(a_mat)
+    keep = eigvals > 0.0
+    if not np.any(keep):
+        return None, None
+    b = (eigvecs[:, keep] * np.sqrt(eigvals[keep])).T  # (k, p): b.T @ b == a_mat
+
+    score_sq = float(s @ s)
+    score_sum_sq = float(s.sum()) ** 2
+    q_rho = np.array(
+        [((1.0 - rho) * score_sq + rho * score_sum_sq) / 2.0 for rho in _SKATO_RHO_GRID],
+        dtype=np.float64,
+    )
+
+    p_value, per_rho = _skato_get_pvalue(q_rho, b, _SKATO_RHO_GRID)
+    best_idx = int(np.argmin(per_rho))
+    best_rho = _SKATO_RHO_GRID[best_idx]
+    if best_rho >= 0.999:
+        best_rho = 1.0
+    if not np.isfinite(p_value):
+        return None, best_rho
+    return float(np.clip(p_value, 0.0, 1.0)), best_rho
+
+
+__all__ = ["meta_burden", "meta_skat", "meta_skato"]

--- a/variantcentrifuge/association/meta/heterogeneity.py
+++ b/variantcentrifuge/association/meta/heterogeneity.py
@@ -1,0 +1,106 @@
+# File: variantcentrifuge/association/meta/heterogeneity.py
+"""
+Heterogeneity diagnostics for cohort meta-analysis.
+
+- Per-stratum burden effect and standard error from the score/covariance.
+- Cochran's Q, its p-value, and I-squared across strata with non-zero information
+  (df = usable strata - 1).
+- Leave-one-stratum-out re-combination.
+- An explicit, opt-in ACAT companion combining per-stratum p-values — offered as a
+  heterogeneity-robust complement, never a silent substitute for the common-effect
+  score test.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+import numpy as np
+import scipy.stats
+
+logger = logging.getLogger("variantcentrifuge")
+
+
+def per_stratum_burden(
+    u_list: list[np.ndarray],
+    v_list: list[np.ndarray],
+    weights: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return per-stratum burden effect estimates and standard errors.
+
+    ``beta_c = (wᵀU_c) / (wᵀV_c w)``, ``se_c = 1/sqrt(wᵀV_c w)``. Strata with
+    non-positive information get ``beta=nan``, ``se=inf``.
+    """
+    w = np.asarray(weights, dtype=np.float64)
+    betas: list[float] = []
+    ses: list[float] = []
+    for u, v in zip(u_list, v_list, strict=True):
+        score = float(w @ np.asarray(u, dtype=np.float64))
+        info = float(w @ (np.asarray(v, dtype=np.float64) @ w))
+        if info <= 0.0:
+            betas.append(np.nan)
+            ses.append(np.inf)
+        else:
+            betas.append(score / info)
+            ses.append(1.0 / np.sqrt(info))
+    return np.array(betas), np.array(ses)
+
+
+def cochran_q(betas: np.ndarray, ses: np.ndarray) -> tuple[float, float, float]:
+    """Cochran's Q heterogeneity test. Returns (Q, p_value, I²).
+
+    Uses only strata with finite beta and positive, finite SE. df = usable - 1.
+    """
+    betas = np.asarray(betas, dtype=np.float64)
+    ses = np.asarray(ses, dtype=np.float64)
+    usable = np.isfinite(betas) & np.isfinite(ses) & (ses > 0)
+    b = betas[usable]
+    s = ses[usable]
+    k = b.size
+    if k < 2:
+        return 0.0, 1.0, 0.0
+    w = 1.0 / (s**2)
+    beta_bar = float(np.sum(w * b) / np.sum(w))
+    q = float(np.sum(w * (b - beta_bar) ** 2))
+    df = k - 1
+    p = float(scipy.stats.chi2.sf(q, df))
+    i2 = max(0.0, (q - df) / q) if q > 0 else 0.0
+    return q, p, i2
+
+
+def leave_one_out(
+    u_list: list[np.ndarray],
+    v_list: list[np.ndarray],
+    weights: np.ndarray,
+    stratum_ids: list[str],
+    combine_fn: Callable[[list[np.ndarray], list[np.ndarray], np.ndarray], float | None],
+) -> list[tuple[str, float | None]]:
+    """Recompute the meta p-value dropping each stratum in turn.
+
+    ``combine_fn`` maps (u_list, v_list, weights) -> p_value (e.g. a lambda over
+    ``meta_burden``/``meta_skat``). Returns [(dropped_stratum_id, p_value), ...].
+    """
+    if len(u_list) < 2:
+        return []
+    results: list[tuple[str, float | None]] = []
+    for i, sid in enumerate(stratum_ids):
+        u_sub = [u for j, u in enumerate(u_list) if j != i]
+        v_sub = [v for j, v in enumerate(v_list) if j != i]
+        results.append((sid, combine_fn(u_sub, v_sub, weights)))
+    return results
+
+
+def acat_companion(p_values: list[float | None]) -> float | None:
+    """Explicit ACAT (Cauchy) combination of per-stratum p-values (companion only)."""
+    from variantcentrifuge.association.tests.acat import cauchy_combination
+
+    return cauchy_combination(p_values)
+
+
+__all__ = [
+    "acat_companion",
+    "cochran_q",
+    "leave_one_out",
+    "per_stratum_burden",
+]

--- a/variantcentrifuge/association/meta/manifest.py
+++ b/variantcentrifuge/association/meta/manifest.py
@@ -1,0 +1,120 @@
+# File: variantcentrifuge/association/meta/manifest.py
+"""
+Study-manifest reading and cross-stratum comparability validation.
+
+The manifest is a small TSV: one row per stratum with columns ``stratum_id`` and
+``artifact_path``. Before any combination, strata must be comparable — the meta
+step refuses (hard error, no silent fallback) when strata disagree on genome
+build, annotation version, mask definition, or trait type, or when their
+(hashed) sample sets overlap (overlap violates the additive-covariance
+independence assumption; issue #112 forbids shared controls).
+
+Sample-hash non-overlap does NOT by itself establish independence for related or
+shared-control populations — that remains an explicit caller assumption.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+from dataclasses import dataclass
+
+from variantcentrifuge.association.meta.artifact import ScoreCovarianceArtifact, load_artifact
+
+logger = logging.getLogger("variantcentrifuge")
+
+
+class MetaCompatibilityError(ValueError):
+    """Raised when strata are not comparable and must not be pooled."""
+
+
+@dataclass
+class StratumRef:
+    """One manifest row: a stratum id and the path to its artifact."""
+
+    stratum_id: str
+    artifact_path: str
+
+
+def read_study_manifest(path: str) -> list[StratumRef]:
+    """Read a study manifest TSV (columns: stratum_id, artifact_path)."""
+    refs: list[StratumRef] = []
+    with open(path, encoding="utf-8") as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        required = {"stratum_id", "artifact_path"}
+        if reader.fieldnames is None or not required.issubset(reader.fieldnames):
+            raise MetaCompatibilityError(
+                f"Manifest '{path}' must have columns {sorted(required)}; found {reader.fieldnames}"
+            )
+        for row in reader:
+            sid = (row.get("stratum_id") or "").strip()
+            apath = (row.get("artifact_path") or "").strip()
+            if not sid or not apath:
+                raise MetaCompatibilityError(
+                    f"Manifest '{path}' has a row with empty fields: {row}"
+                )
+            refs.append(StratumRef(stratum_id=sid, artifact_path=apath))
+    if len(refs) < 2:
+        raise MetaCompatibilityError(
+            f"Manifest '{path}' lists {len(refs)} stratum; meta-analysis needs at least 2."
+        )
+    seen: set[str] = set()
+    for ref in refs:
+        if ref.stratum_id in seen:
+            raise MetaCompatibilityError(f"Duplicate stratum_id '{ref.stratum_id}' in manifest.")
+        seen.add(ref.stratum_id)
+    return refs
+
+
+def load_manifest_artifacts(refs: list[StratumRef]) -> list[ScoreCovarianceArtifact]:
+    """Load every artifact referenced by the manifest (clear error on missing file)."""
+    artifacts: list[ScoreCovarianceArtifact] = []
+    for ref in refs:
+        try:
+            artifacts.append(load_artifact(ref.artifact_path))
+        except FileNotFoundError as exc:
+            raise MetaCompatibilityError(
+                f"Artifact for stratum '{ref.stratum_id}' not found: {ref.artifact_path}"
+            ) from exc
+    return artifacts
+
+
+def validate_comparability(artifacts: list[ScoreCovarianceArtifact]) -> None:
+    """Raise MetaCompatibilityError unless all strata are comparable.
+
+    Checks: identical genome_build, annotation_version, mask_hash, trait_type,
+    and disjoint sample_id_hashes across strata.
+    """
+    if len(artifacts) < 2:
+        raise MetaCompatibilityError("Need at least 2 strata to validate comparability.")
+
+    def _uniform(attr: str) -> None:
+        values = {getattr(a, attr) for a in artifacts}
+        if len(values) > 1:
+            raise MetaCompatibilityError(
+                f"Strata disagree on '{attr}': {sorted(map(str, values))}. "
+                "Refusing to pool non-comparable strata (no silent fallback)."
+            )
+
+    for attr in ("genome_build", "annotation_version", "mask_hash", "trait_type"):
+        _uniform(attr)
+
+    # Sample-hash overlap check (independence of covariances).
+    seen: dict[str, str] = {}
+    for art in artifacts:
+        for h in art.sample_id_hashes:
+            if h in seen and seen[h] != art.stratum_id:
+                raise MetaCompatibilityError(
+                    f"Sample overlap between strata '{seen[h]}' and '{art.stratum_id}'. "
+                    "Shared samples/controls violate the additive-covariance assumption."
+                )
+            seen[h] = art.stratum_id
+
+
+__all__ = [
+    "MetaCompatibilityError",
+    "StratumRef",
+    "load_manifest_artifacts",
+    "read_study_manifest",
+    "validate_comparability",
+]

--- a/variantcentrifuge/association/meta/runner.py
+++ b/variantcentrifuge/association/meta/runner.py
@@ -1,0 +1,190 @@
+# File: variantcentrifuge/association/meta/runner.py
+"""
+End-to-end meta-analysis orchestration: manifest → per-gene combination → TSV.
+
+For each gene present in the study, align the contributing strata, harmonise
+weights from pooled frequency, run the common-effect burden/SKAT/SKAT-O meta,
+compute heterogeneity and leave-one-out, then apply exome-wide multiplicity
+correction to the primary (SKAT-O) p-value.
+
+This runner handles a single declared mask (all artifacts share ``mask_hash``,
+enforced by comparability validation). Multi-mask designs run this once per mask
+and ACAT-combine the per-gene primaries at a higher level.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pandas as pd
+
+from variantcentrifuge.association.correction import apply_correction
+from variantcentrifuge.association.meta.align import align_strata, pooled_frequency_weights
+from variantcentrifuge.association.meta.artifact import GeneScore, ScoreCovarianceArtifact
+from variantcentrifuge.association.meta.combine import meta_burden, meta_skat, meta_skato
+from variantcentrifuge.association.meta.heterogeneity import (
+    cochran_q,
+    leave_one_out,
+    per_stratum_burden,
+)
+from variantcentrifuge.association.meta.manifest import (
+    load_manifest_artifacts,
+    read_study_manifest,
+    validate_comparability,
+)
+
+logger = logging.getLogger("variantcentrifuge")
+
+OUTPUT_COLUMNS = [
+    "gene",
+    "mask",
+    "n_strata",
+    "n_cases_total",
+    "n_controls_total",
+    "n_variants_union",
+    "meta_burden_p",
+    "meta_burden_beta",
+    "meta_burden_direction",
+    "meta_skat_p",
+    "meta_skato_p",
+    "meta_skato_rho",
+    "het_q",
+    "het_p",
+    "het_i2",
+    "per_stratum_directions",
+    "loo_min_p",
+    "primary_p",
+    "primary_q",
+    "status",
+    "warnings",
+]
+
+
+def _gene_row(
+    gene: str,
+    mask_id: str,
+    contributors: list[tuple[ScoreCovarianceArtifact, GeneScore]],
+    weight_scheme: str,
+) -> dict:
+    """Combine one gene's contributing strata into a single result row."""
+    warnings: list[str] = []
+    kept = [(art, gs) for art, gs in contributors if gs.null_converged]
+    dropped = [art.stratum_id for art, gs in contributors if not gs.null_converged]
+    if dropped:
+        warnings.append(f"excluded_non_converged:{','.join(sorted(dropped))}")
+
+    n_strata = len(kept)
+    if n_strata == 0:
+        return {
+            "gene": gene,
+            "mask": mask_id,
+            "n_strata": 0,
+            "status": "no_converged_strata",
+            "warnings": ";".join(warnings) or None,
+        }
+
+    gene_scores = [gs for _art, gs in kept]
+    u_list, v_list, ac_pooled, an_pooled, union_keys = align_strata(gene_scores)
+    weights = pooled_frequency_weights(ac_pooled, an_pooled, weight_scheme)
+
+    burden_p, beta, direction = meta_burden(u_list, v_list, weights)
+    skat_p, _method = meta_skat(u_list, v_list, weights)
+    skato_p, rho = meta_skato(u_list, v_list, weights)
+
+    betas, ses = per_stratum_burden(u_list, v_list, weights)
+    het_q, het_p, het_i2 = cochran_q(betas, ses)
+    directions = [int(np.sign(b)) if np.isfinite(b) else 0 for b in betas]
+
+    loo = leave_one_out(
+        u_list,
+        v_list,
+        weights,
+        [art.stratum_id for art, _gs in kept],
+        lambda u, v, w: meta_burden(u, v, w)[0],
+    )
+    loo_ps = [p for _sid, p in loo if p is not None]
+    loo_min_p = min(loo_ps) if loo_ps else None
+
+    primary_p = skato_p if skato_p is not None else burden_p
+    status = "ok" if n_strata >= 2 else "single_stratum"
+    if primary_p is None:
+        status = "degenerate"
+
+    return {
+        "gene": gene,
+        "mask": mask_id,
+        "n_strata": n_strata,
+        "n_cases_total": int(sum(art.n_cases for art, _gs in kept)),
+        "n_controls_total": int(sum(art.n_controls for art, _gs in kept)),
+        "n_variants_union": len(union_keys),
+        "meta_burden_p": burden_p,
+        "meta_burden_beta": beta,
+        "meta_burden_direction": direction,
+        "meta_skat_p": skat_p,
+        "meta_skato_p": skato_p,
+        "meta_skato_rho": rho,
+        "het_q": het_q,
+        "het_p": het_p,
+        "het_i2": het_i2,
+        "per_stratum_directions": ",".join(str(d) for d in directions),
+        "loo_min_p": loo_min_p,
+        "primary_p": primary_p,
+        "primary_q": None,
+        "status": status,
+        "warnings": ";".join(warnings) or None,
+    }
+
+
+def meta_analyze_artifacts(
+    artifacts: list[ScoreCovarianceArtifact],
+    weight_scheme: str = "beta:1,25",
+    correction: str = "fdr",
+) -> pd.DataFrame:
+    """Combine already-loaded, already-validated artifacts into a results frame."""
+    mask_id = artifacts[0].mask_id
+    all_genes = sorted({g for art in artifacts for g in art.genes})
+
+    rows: list[dict] = []
+    for gene in all_genes:
+        contributors = [(art, art.genes[gene]) for art in artifacts if gene in art.genes]
+        rows.append(_gene_row(gene, mask_id, contributors, weight_scheme))
+
+    df = pd.DataFrame(rows).reindex(columns=OUTPUT_COLUMNS)
+
+    testable = df["primary_p"].notna()
+    if testable.any():
+        corrected = apply_correction(
+            df.loc[testable, "primary_p"].to_numpy(dtype=float), correction
+        )
+        df.loc[testable, "primary_q"] = corrected
+
+    n_sig = int((df["primary_q"] < 0.05).sum())
+    logger.info(
+        "Meta-analysis complete: %d genes, %d with valid primary, %d significant (q<0.05)",
+        len(df),
+        int(testable.sum()),
+        n_sig,
+    )
+    return df
+
+
+def run_meta(
+    manifest_path: str,
+    output_path: str,
+    weight_scheme: str = "beta:1,25",
+    correction: str = "fdr",
+) -> pd.DataFrame:
+    """Full pipeline: manifest → validated artifacts → meta results → TSV."""
+    refs = read_study_manifest(manifest_path)
+    artifacts = load_manifest_artifacts(refs)
+    validate_comparability(artifacts)
+    logger.info("Meta-analysis: %d strata, mask '%s'", len(artifacts), artifacts[0].mask_id)
+
+    df = meta_analyze_artifacts(artifacts, weight_scheme=weight_scheme, correction=correction)
+    df.to_csv(output_path, sep="\t", index=False)
+    logger.info("Wrote meta results to %s", output_path)
+    return df
+
+
+__all__ = ["OUTPUT_COLUMNS", "meta_analyze_artifacts", "run_meta"]


### PR DESCRIPTION
## Summary

Implements #112: cohort-stratified rare-variant **score-statistic** meta-analysis. It combines two or more clinically distinct case-control **strata** into one calibrated exome-wide discovery analysis — without pooling under a cohort covariate, and without discarding direction/covariance by combining per-gene p-values.

**Enabling insight:** the SKAT backend already computes the per-gene score vector `U = Gᵀr` and projection-adjusted covariance `V = GᵀPG`, then throws them away. This PR persists them per stratum as **aggregate-only** artifacts (no per-sample rows, no phenotype values) and combines them, **reusing the existing Davies chain and SKAT-O omnibus unchanged**.

## What's in it

New `variantcentrifuge/association/meta/` package (8 modules, each well under the 600-line budget) + a `variantcentrifuge-meta` console script that consumes artifacts (no VCF, no external tools):

| Module | Responsibility |
|---|---|
| `artifact.py` | score/covariance artifact schema + gene-level computation |
| `combine.py` | common-effect burden / SKAT / SKAT-O meta |
| `align.py` | canonical-key union alignment + pooled-frequency weight harmonisation |
| `heterogeneity.py` | Cochran Q, I², per-stratum direction, leave-one-cohort-out, ACAT companion |
| `manifest.py` | study manifest + comparability/safety refusal |
| `runner.py` | orchestration + exome-wide FDR + TSV output |
| `cli.py` | `variantcentrifuge-meta` entry point |

Design docs: `docs/superpowers/specs/2026-07-20-cohort-meta-analysis-design.md` and the matching plan. User guide: `docs/source/guides/meta_analysis.md`.

## Statistical correctness

- `U`/`V` stored **unweighted**; weights harmonised from the **pooled** ALT frequency at meta time (`MAF = min(af, 1-af)`), because cohort-specific MAF weights put `U`/`V` on incompatible scales.
- **Golden gate:** a single-stratum meta reproduces `_test_skat` at `rel=1e-6` and `_test_skato` at `rel=1e-4` — tying the new engine to already-validated code.
- Meta-SKAT-O reduces to an **exact** factorisation of `Σ/2` fed to the existing `_skato_get_pvalue` (which depends on the per-sample matrix only through `A = z1ᵀz1`).

## Guardrails (issue non-goals)

- Refuses to pool strata that disagree on genome build / annotation / mask, or that **share samples** (hashed) — no silent p-value-combination fallback.
- Artifacts and reports carry only aggregate quantities; a test asserts no sample IDs / phenotype rows.

## Adversarial review

The spec + plan were reviewed by Codex (high effort) before implementation. Five real issues were caught and fixed: quantitative `U`/`V` mis-scaling (**scoped to binary**), non-exact SKAT-O factorisation (keep all non-negative eigenmodes), `AC`/`AN` from imputed rather than raw dosage, a bogus convergence flag, and non-reproducible functional weights (**restricted to Beta/uniform**). See spec §12.

## Testing

- **33 new tests** covering all six issue acceptance criteria (concordant power, opposite-direction heterogeneity, imbalance calibration, callability refusal, config/overlap validation, safe-aggregate outputs) + the golden gate.
- **No regressions:** 146 tests pass in the association area (including the SKAT backend whose private helpers this code imports).
- `ruff`, `ruff format`, `mypy` clean; LOC budget satisfied.
- Note: `make ci-check`'s `test-fast` step shows 15 failures in this environment, all `ModuleNotFoundError: xlsxwriter` — a **pre-existing missing optional dependency**, unrelated to this change (Excel-export tests).

## Scope

This deliberately reverses two `PROJECT.md` non-goals (cross-cohort meta-analysis; the mixed-model null seam). `PROJECT.md` is updated to **ratify** the change and to narrow the remaining out-of-scope items.

**Deferred behind interface seams** (documented, no schema change required to add): genotype-level SPA for *severe* imbalance, GLMM/GRM null backend, quantitative traits, and wiring the artifact-emission flag into the live VCF stage (artifacts are already producible via the tested `build_stratum_artifact` API).

Closes #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNBHucSGRkzMCpc14CzL4H
